### PR TITLE
Remember scroll position per file when switching files

### DIFF
--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -105,6 +105,7 @@
   let windowWidth = 1200;
   let lastActiveFileId: string | null = null;
   let editorContainer: HTMLDivElement | null = null;
+  const fileScrollPositions = new Map<string, number>();
 
   let showCloneForm = false;
   let cloneUrl = '';
@@ -152,6 +153,13 @@
       console.error('editor build:', err);
     }
 
+    if (editorView) {
+      const saved = fileScrollPositions.get(file.id);
+      if (saved !== undefined) {
+        editorView.scrollDOM.scrollTop = saved;
+      }
+    }
+
     lastActiveFileId = file.id;
   }
 
@@ -180,13 +188,30 @@
     };
   }
 
+  // clean up cursor positions when active files change (z.B. file closed)
+  $: {
+    const openIds = new Set($files.map((f) => f.id));
+    for (const id of fileScrollPositions.keys()) {
+      if (!openIds.has(id)) fileScrollPositions.delete(id);
+    }
+  }
+
   // rebuild editor when active file changes (skip drawio files)
   $: if ($activeFile && $activeFile.id !== lastActiveFileId && editorContainer && !isDrawioFile($activeFile.name)) {
+    if (editorView && lastActiveFileId) {
+      fileScrollPositions.set(lastActiveFileId, editorView.scrollDOM.scrollTop);
+    }
+
     if (get(collabActive)) {
       buildEditor();
     } else if (editorView) {
       lastActiveFileId = $activeFile.id;
       replaceEditorContent(editorView, $activeFile.content);
+
+      const saved = fileScrollPositions.get($activeFile.id);
+      if (saved !== undefined) {
+        editorView.scrollDOM.scrollTop = saved;
+      }
     }
   }
 

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -153,14 +153,17 @@
       console.error('editor build:', err);
     }
 
-    if (editorView) {
-      const saved = fileScrollPositions.get(file.id);
-      if (saved !== undefined) {
-        editorView.scrollDOM.scrollTop = saved;
-      }
-    }
+    restoreScrollPosition(file.id);
 
     lastActiveFileId = file.id;
+  }
+
+  function restoreScrollPosition(fileId: string) {
+    if (!editorView) return;
+    const saved = fileScrollPositions.get(fileId);
+    if (saved !== undefined) {
+      editorView.scrollDOM.scrollTop = saved;
+    }
   }
 
   // svelte action: creates codemirror when the element enters the dom
@@ -188,7 +191,7 @@
     };
   }
 
-  // clean up cursor positions when active files change (z.B. file closed)
+  // drop scroll positions of files that are no longer open
   $: {
     const openIds = new Set($files.map((f) => f.id));
     for (const id of fileScrollPositions.keys()) {
@@ -207,11 +210,7 @@
     } else if (editorView) {
       lastActiveFileId = $activeFile.id;
       replaceEditorContent(editorView, $activeFile.content);
-
-      const saved = fileScrollPositions.get($activeFile.id);
-      if (saved !== undefined) {
-        editorView.scrollDOM.scrollTop = saved;
-      }
+      restoreScrollPosition($activeFile.id);
     }
   }
 


### PR DESCRIPTION
When switching between open tabs the editor now restores the scroll position of each file. Previously the editor always jumped back to the top on every file switch.