### PR TITLE
problems tab, plain words for latex errors, a readable log

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,4 +19,5 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm check
+      - run: pnpm test
       - run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm check
+      - run: pnpm test
       - run: pnpm build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ build/
 .DS_Store
 *.local
 *.log
+# real engine transcripts the parser tests run against
+!src/lib/compiler/fixtures/*.log
 *.tgz

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ There's no magic and no backend.
 
 **Frontend.** [SvelteKit](https://kit.svelte.dev/) with the static adapter. The entire app is pre-built to static HTML/CSS/JS and deployed to GitHub Pages. No SSR, no API routes, no server. [Tailwind CSS](https://tailwindcss.com/) handles styling.
 
+## When something doesn't compile
+
+LaTeX errors are famous for being unreadable, so TeXbrain does the reading for you. The Problems tab turns the log into cards: a headline in plain words ("Unknown command \foo", "Math outside math mode", "Package doesnotexist not found"), what it means, what to try, the file and line, and the source line exactly as TeX read it with a bar where it stopped. Click a card and the editor jumps there, opening the file if it has to. Errors that TeX can't place, a missing package for example, are placed by searching your sources for them.
+
+Warnings get the same treatment (undefined labels, citations, hyperref bookmarks). Notes about margins and stretched lines are there too, hidden until you switch them on. Every card can be copied as text, "Copy all" gives you a report to paste anywhere, and problems that look like TeXbrain's fault rather than your document's have a link that opens a prefilled issue.
+
+The Log tab still has everything the engine printed, with colors, line numbers, search, a full/clean toggle, copy and download.
+
 ## Git, step by step
 
 Git in TeXbrain works on the folder you opened, the same way a terminal would. A hidden `.git` directory sits next to your `.tex` files, so you can switch between TeXbrain, the command line and any other editor without anything getting out of sync. Folders that already are repositories are picked up as they are, history included.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run"
   },
   "engines": {
     "node": ">=20"
@@ -22,7 +23,8 @@
     "svelte-check": "^4.1.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.11"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
 
 packages:
 
@@ -634,8 +637,14 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -645,6 +654,35 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -658,6 +696,10 @@ packages:
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
@@ -688,6 +730,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -698,6 +744,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
@@ -761,6 +810,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -776,6 +828,9 @@ packages:
   esrap@2.2.3:
     resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -783,6 +838,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -993,11 +1052,18 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pdfjs-dist@4.10.38:
     resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
@@ -1068,6 +1134,9 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -1084,6 +1153,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1110,9 +1185,20 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -1185,12 +1271,58 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -1630,7 +1762,14 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -1641,6 +1780,47 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -1648,6 +1828,8 @@ snapshots:
   acorn@8.16.0: {}
 
   aria-query@5.3.1: {}
+
+  assertion-error@2.0.1: {}
 
   async-lock@1.4.1: {}
 
@@ -1681,6 +1863,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  chai@6.2.2: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -1688,6 +1872,8 @@ snapshots:
   clean-git-ref@2.0.1: {}
 
   clsx@2.1.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie@0.6.0: {}
 
@@ -1734,6 +1920,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.2: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -1773,9 +1961,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
+
+  expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -1943,11 +2137,15 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  obug@2.1.4: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
 
   pako@1.0.11: {}
+
+  pathe@2.0.3: {}
 
   pdfjs-dist@4.10.38:
     optionalDependencies:
@@ -2045,6 +2243,8 @@ snapshots:
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
 
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -2072,6 +2272,10 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -2114,10 +2318,16 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.1: {}
 
   to-buffer@1.2.2:
     dependencies:
@@ -2158,6 +2368,33 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
 
+  vitest@4.1.11(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.1
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   which-typed-array@1.1.20:
@@ -2169,6 +2406,11 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 

--- a/src/lib/collab/provider.ts
+++ b/src/lib/collab/provider.ts
@@ -259,7 +259,7 @@ export function setCompileResult(result: {
   status: 'success' | 'error';
   pdf: Uint8Array | null;
   log: string[];
-  errors: Array<{ type: string; message: string; line?: number; file?: string }>;
+  errors: unknown[];
   pageCount: number;
 }) {
   if (!ydoc) return;

--- a/src/lib/compiler/explain.ts
+++ b/src/lib/compiler/explain.ts
@@ -1,0 +1,34 @@
+// what a tex message means in plain words, and what to do about it
+
+import type { Severity } from './log';
+
+export interface Explanation {
+  title: string;
+  explain?: string;
+  fix?: string;
+  // something to search the sources for when tex gave no line
+  needle?: string;
+  // a warning that is really just a note, or the other way round
+  severity?: Severity;
+}
+
+export interface Where {
+  // the source text before the spot where tex stopped reading
+  before?: string;
+  file?: string;
+  inPackage: boolean;
+}
+
+// the message as tex wrote it, minus the prefixes nobody needs to read twice
+function tidy(message: string): string {
+  return message
+    .replace(/^LaTeX Error:\s*/, '')
+    .replace(/^Package ([\w.-]+) Error:\s*/, '$1: ')
+    .replace(/^Class ([\w.-]+) Error:\s*/, '$1: ')
+    .replace(/\s*\.$/, '')
+    .trim();
+}
+
+export function explain(kind: Severity, message: string, where: Where): Explanation {
+  return { title: tidy(message) };
+}

--- a/src/lib/compiler/explain.ts
+++ b/src/lib/compiler/explain.ts
@@ -19,6 +19,12 @@ export interface Where {
   inPackage: boolean;
 }
 
+interface Rule {
+  kind: Severity;
+  test: RegExp;
+  make: (m: RegExpMatchArray, where: Where) => Explanation;
+}
+
 // the message as tex wrote it, minus the prefixes nobody needs to read twice
 function tidy(message: string): string {
   return message
@@ -29,6 +35,322 @@ function tidy(message: string): string {
     .trim();
 }
 
+// tex stops reading right after the thing it stumbled over, so the last
+// command in the context is usually the culprit
+function lastCommand(before?: string): string | undefined {
+  if (!before) return undefined;
+  const m = before.match(/(\\(?:[A-Za-z@]+|[^A-Za-z@\s]))\s*$/) || before.match(/(\\[A-Za-z@]+)(?!.*\\[A-Za-z@]+)/);
+  return m ? m[1] : undefined;
+}
+
+const ENV_PACKAGES: Record<string, string> = {
+  'align': 'amsmath', 'align*': 'amsmath', 'gather': 'amsmath', 'gather*': 'amsmath', 'multline': 'amsmath',
+  'split': 'amsmath', 'cases': 'amsmath', 'subequations': 'amsmath', 'alignat': 'amsmath',
+  'tabularx': 'tabularx', 'longtable': 'longtable', 'tikzpicture': 'tikz', 'subfigure': 'subcaption',
+  'lstlisting': 'listings', 'algorithm': 'algorithm', 'algorithmic': 'algorithmic', 'multicols': 'multicol',
+  'wrapfigure': 'wrapfig', 'framed': 'framed', 'tcolorbox': 'tcolorbox', 'proof': 'amsthm',
+  'comment': 'comment', 'landscape': 'lscape', 'minipage*': 'the LaTeX kernel, check the spelling'
+};
+
+const RULES: Rule[] = [
+  // ---- commands and math -------------------------------------------------
+  {
+    kind: 'error',
+    test: /^Undefined control sequence/,
+    make: (_m, where) => {
+      const cmd = lastCommand(where.before);
+      return {
+        title: cmd ? `Unknown command ${cmd}` : 'Unknown command',
+        explain: `LaTeX doesn't know ${cmd ?? 'this command'}. Either it is misspelled, or the package that defines it isn't loaded.`,
+        fix: 'Check the spelling, or add the \\usepackage that provides it. Common ones: \\toprule needs booktabs, \\includegraphics needs graphicx, \\url needs url or hyperref, \\SI needs siunitx, \\textcolor needs xcolor.'
+      };
+    }
+  },
+  {
+    kind: 'error',
+    test: /^Missing \$ inserted/,
+    make: () => ({
+      title: 'Math outside math mode',
+      explain: 'Something on this line only works in math mode: _ and ^, or a command like \\frac or \\alpha.',
+      fix: 'Put it between $ and $. If you mean the characters themselves, write \\_ and \\^{}.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Display math should end with \$\$|^Bad math environment delimiter/,
+    make: () => ({
+      title: 'Math delimiters don\'t match',
+      explain: 'What opens math has to close it too.',
+      fix: '$ closes what $ opened, \\] closes \\[, and \\end{equation} closes \\begin{equation}. Check the pairs on this line.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Missing \} inserted|^Missing \{ inserted|^Too many \}'s|^Extra \}, or forgotten (\$|\\endgroup|\\right)|^Argument of \\\S+ has an extra \}/,
+    make: () => ({
+      title: 'Braces don\'t add up',
+      explain: 'A { or } is missing, or there is one too many.',
+      fix: 'Count the braces on this line and the ones above it. The editor highlights the matching brace when the cursor is next to one.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Double (subscript|superscript)/,
+    make: (m) => ({
+      title: `Two ${m[1] === 'subscript' ? '_' : '^'} in a row`,
+      explain: 'TeX can\'t tell what belongs to what.',
+      fix: 'Group the inner one: a_{b_c} instead of a_b_c.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Missing \\right\. inserted|^Extra \\right/,
+    make: () => ({
+      title: '\\left and \\right don\'t match',
+      fix: 'Every \\left( needs a \\right) in the same formula. Use \\right. when you want no bracket on that side.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Please use \\mathaccent for accents in math mode/,
+    make: () => ({
+      title: 'Text accent inside math',
+      fix: 'In math mode use \\hat{a}, \\bar{a}, \\vec{a} instead of \\^ and friends.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Missing number, treated as zero/,
+    make: () => ({
+      title: 'A number was expected',
+      explain: 'A length, a counter or an option got text where a number belongs.',
+      fix: 'Look at the last command on this line, one of its arguments needs a number, often with a unit like 2cm.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Illegal unit of measure/,
+    make: () => ({
+      title: 'Missing unit',
+      fix: 'Lengths need a unit: 2cm, 10pt, 0.5\\textwidth.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Missing control sequence inserted/,
+    make: () => ({
+      title: '\\newcommand needs a command name',
+      fix: 'The first argument is the command itself, backslash included: \\newcommand{\\name}{...}.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Use of (\\\S+) doesn't match its definition|^Missing \\endcsname inserted/,
+    make: (m) => ({
+      title: m[1] ? `${m[1]} used the wrong way` : 'A command was used the wrong way',
+      fix: 'Compare the arguments on this line with what the command expects. Optional arguments go in [ ], required ones in { }.'
+    })
+  },
+
+  // ---- structure ---------------------------------------------------------
+  {
+    kind: 'error',
+    test: /^Paragraph ended before (\\\S+) was complete/,
+    make: (m) => ({
+      title: 'Blank line inside an argument',
+      explain: `There is an empty line inside the argument of ${m[1]}, and most commands can't take one.`,
+      fix: 'Remove the blank line, or end the paragraph with \\par instead.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^File ended while scanning (?:use|text|definition) of (\\\S+)/,
+    make: (m) => ({
+      title: 'Something was never closed',
+      explain: `${m[1]} was still waiting for its closing brace when the file ended. The runaway text below shows what it swallowed.`,
+      fix: `Look for a { without its } after the last ${m[1]}, or a \\begin without its \\end.`
+    })
+  },
+  {
+    kind: 'error',
+    test: /^File ended while scanning/,
+    make: () => ({
+      title: 'Something was never closed',
+      fix: 'A brace, a bracket or an environment is still open at the end of the file.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^(?:LaTeX Error: )?Missing \\begin\{document\}/,
+    make: () => ({
+      title: 'Text before \\begin{document}',
+      explain: 'Something in the preamble prints text. Only definitions, \\usepackage and settings belong before \\begin{document}.',
+      fix: 'Look for a stray character or a misspelled command above \\begin{document}. A typo in a package name or an option does this too.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Environment (\S+) undefined/,
+    make: (m) => {
+      const pkg = ENV_PACKAGES[m[1]];
+      return {
+        title: `Unknown environment ${m[1]}`,
+        explain: `\\begin{${m[1]}} needs a package that defines it, or the name is misspelled.`,
+        fix: pkg ? `Add \\usepackage{${pkg}} to the preamble.` : 'Load the package that provides it, or check the spelling.'
+      };
+    }
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: \\begin\{(\S+)\}(?: on input line (\d+))? ended by \\end\{(\S+)\}/,
+    make: (m) => ({
+      title: `\\begin{${m[1]}} closed by \\end{${m[3]}}`,
+      explain: 'Environments close in the reverse order they were opened, each with its own name.',
+      fix: m[2] ? `The \\begin{${m[1]}} is on line ${m[2]}. Give it its own \\end{${m[1]}}, or fix the name.` : `Give \\begin{${m[1]}} its own \\end{${m[1]}}, or fix the name.`
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Something's wrong--perhaps a missing \\item/,
+    make: () => ({
+      title: 'Missing \\item',
+      explain: 'Inside itemize, enumerate and description every entry starts with \\item. Text without one, or an empty list, trips this.',
+      fix: 'Add \\item in front of the text, or remove the empty list.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Lonely \\item/,
+    make: () => ({
+      title: '\\item outside a list',
+      fix: 'Wrap it in \\begin{itemize} ... \\end{itemize} or \\begin{enumerate} ... \\end{enumerate}.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: There's no line here to end/,
+    make: () => ({
+      title: '\\\\ with nothing to break',
+      explain: '\\\\ ends a line of text. On an empty line, or right after a heading, there is no line to end.',
+      fix: 'Remove it. Use an empty line for a new paragraph and \\vspace{...} for extra space.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Misplaced alignment tab character &/,
+    make: () => ({
+      title: '& outside a table',
+      explain: '& separates columns in tabular, align and friends. Anywhere else it is an error.',
+      fix: 'Write \\& for a literal ampersand.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Extra alignment tab has been changed to \\cr/,
+    make: () => ({
+      title: 'Too many columns in a row',
+      explain: 'A row of this table has more & than the column definition allows.',
+      fix: 'Remove the extra &, or add a column to the tabular definition.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Misplaced (\\noalign|\\omit|\\cr)/,
+    make: () => ({
+      title: 'Table command in the wrong place',
+      fix: '\\hline and \\cline only work at the start of a row, right after \\\\. Outside a table they don\'t work at all.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Not in outer par mode/,
+    make: () => ({
+      title: 'Float inside something else',
+      explain: 'figure and table can\'t live inside another float, a minipage, a box or a footnote.',
+      fix: 'Move it out, or drop the figure environment and place the image directly.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Too many unprocessed floats/,
+    make: () => ({
+      title: 'Too many floats waiting',
+      explain: 'LaTeX has more figures and tables in the queue than it can hold.',
+      fix: 'Add \\clearpage somewhere before this point, or give the floats more freedom with [htbp].'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Command (\\\S+) already defined/,
+    make: (m) => ({
+      title: `${m[1]} is defined twice`,
+      fix: 'Use \\renewcommand to change an existing command, or pick another name.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: (?:Command )?(\\\S+) undefined/,
+    make: (m) => ({
+      title: `${m[1]} isn't defined yet`,
+      fix: '\\renewcommand only changes commands that exist. Use \\newcommand for a new one.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Can be used only in preamble/,
+    make: () => ({
+      title: 'Belongs before \\begin{document}',
+      fix: 'Move this line up into the preamble, \\usepackage and \\documentclass settings can\'t come later.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Text line contains an invalid character/,
+    make: () => ({
+      title: 'Invalid character on this line',
+      explain: 'An invisible control character is hiding in the text, usually from a copy and paste.',
+      fix: 'Delete the line and type it again.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^TeX capacity exceeded, sorry \[text input levels/,
+    make: () => ({
+      title: 'Files include each other in a loop',
+      explain: 'A file \\inputs itself, or two files include each other, until TeX gives up.',
+      fix: 'Check the \\input and \\include lines. A file named like a package it loads does this too.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^TeX capacity exceeded, sorry \[(.+)\]/,
+    make: (m) => ({
+      title: `TeX ran out of room (${m[1]})`,
+      explain: 'Almost always a loop: a command that calls itself, or an environment that never ends.',
+      fix: 'Look at what you changed last, and at any \\newcommand that uses its own name.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Emergency stop/,
+    make: () => ({
+      title: 'The compile stopped here',
+      explain: 'TeX gave up without a specific complaint. The log above the stop usually has the reason.',
+      fix: 'Check the full log for the last thing that happened before the stop.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: (.*)/,
+    make: (m) => ({ title: tidy(m[1]) })
+  }
+];
+
 export function explain(kind: Severity, message: string, where: Where): Explanation {
+  for (const rule of RULES) {
+    if (rule.kind !== kind) continue;
+    const m = message.match(rule.test);
+    if (m) return rule.make(m, where);
+  }
   return { title: tidy(message) };
 }

--- a/src/lib/compiler/explain.ts
+++ b/src/lib/compiler/explain.ts
@@ -43,6 +43,35 @@ function lastCommand(before?: string): string | undefined {
   return m ? m[1] : undefined;
 }
 
+const IMAGE = /\.(png|jpe?g|pdf|eps|gif|bmp|tiff?|svg)$/i;
+
+function fileNotFound(name: string): Explanation {
+  const base = name.replace(/\.[^.]+$/, '');
+  if (/\.(sty|cls)$/.test(name)) {
+    const isClass = name.endsWith('.cls');
+    return {
+      title: `${isClass ? 'Class' : 'Package'} ${base} not found`,
+      explain: `${name} isn't bundled with the app and the TeX Live mirror doesn't have it either, or the name is misspelled.`,
+      fix: `Check the spelling in \\${isClass ? 'documentclass' : 'usepackage'}. If it exists on CTAN and still fails here, open an issue with the name.`,
+      needle: base
+    };
+  }
+  if (IMAGE.test(name)) {
+    return {
+      title: `Image ${name} not found`,
+      explain: 'The file isn\'t in the project, at least not under that name and path.',
+      fix: 'Check the name, the extension and the folder. Open the whole project folder so every file reaches the compiler.',
+      needle: name
+    };
+  }
+  return {
+    title: `File ${name} not found`,
+    explain: 'Nothing with that name is in the project.',
+    fix: 'Check the name and the path. Open the whole project folder so every file reaches the compiler.',
+    needle: base
+  };
+}
+
 const ENV_PACKAGES: Record<string, string> = {
   'align': 'amsmath', 'align*': 'amsmath', 'gather': 'amsmath', 'gather*': 'amsmath', 'multline': 'amsmath',
   'split': 'amsmath', 'cases': 'amsmath', 'subequations': 'amsmath', 'alignat': 'amsmath',
@@ -339,10 +368,266 @@ const RULES: Rule[] = [
       fix: 'Check the full log for the last thing that happened before the stop.'
     })
   },
+  // ---- files, packages, images, fonts -------------------------------------
+  {
+    kind: 'error',
+    test: /^LaTeX Error: File `([^']+)' not found/,
+    make: (m) => fileNotFound(m[1])
+  },
+  {
+    kind: 'error',
+    test: /^Package pdftex\.def Error: File `([^']+)' not found/,
+    make: (m) => fileNotFound(m[1])
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Unknown graphics extension: (\S+)/,
+    make: (m) => ({
+      title: `Image format ${m[1]} isn't supported`,
+      explain: 'pdfTeX reads PNG, JPG and PDF, nothing else.',
+      fix: `Convert the ${m[1]} file to PNG or PDF and include that.`
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Cannot determine size of graphic in (\S+)/,
+    make: (m) => ({
+      title: `Can't read the size of ${m[1]}`,
+      explain: 'The image is broken, or in a format pdfTeX can\'t measure.',
+      fix: 'Export it again as PNG or PDF, or give width and height explicitly.',
+      needle: m[1]
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Option clash for package (\S+)/,
+    make: (m) => ({
+      title: `Package ${m[1]} loaded twice with different options`,
+      explain: 'Another package already loaded it, with other options, and LaTeX can\'t load a package twice.',
+      fix: `Put \\PassOptionsToPackage{...}{${m[1]}} before the first \\usepackage, or move the options into \\documentclass.`,
+      needle: m[1]
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Package babel Error: Unknown option `([^']+)'/,
+    make: (m) => ({
+      title: `babel doesn't know the language ${m[1]}`,
+      explain: 'The option isn\'t a language this babel ships, or its name changed between versions.',
+      fix: 'Check the spelling in \\usepackage[...]{babel}. brazil and brazilian are the same language, ngerman is the modern german.',
+      needle: m[1]
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Package inputenc Error: (?:Invalid UTF-8 byte|Unicode character)/,
+    make: () => ({
+      title: 'The file isn\'t valid UTF-8',
+      explain: 'A character on this line can\'t be read as UTF-8, often after a copy from another program.',
+      fix: 'Delete and retype the character, or save the file as UTF-8.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^LaTeX Error: Unicode character (.+?) (?:\(U\+\w+\) )?not set up for use with LaTeX/,
+    make: (m) => ({
+      title: `The character ${m[1]} isn't available`,
+      explain: 'The font encoding in use has no glyph for it.',
+      fix: 'Use the LaTeX command for it, or add \\usepackage[T1]{fontenc} for accented letters.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Font \S+=(\S+) .*not loadable: (?:Bad metric \(TFM\) file|Metric \(TFM\) file not found)/,
+    make: (m) => ({
+      title: `Font ${m[1]} couldn't be loaded`,
+      explain: 'The metric file for this font is missing or broken. In TeXbrain that usually means a download went wrong and got cached.',
+      fix: 'Reload the page and compile again. If it keeps happening, clear the site data for tex.swimmingbrain.dev and open an issue with the full log.'
+    })
+  },
+  {
+    kind: 'error',
+    test: /^Package ([\w.-]+) Error: (.*)/,
+    make: (m) => ({
+      title: `${m[1]}: ${tidy(m[2])}`,
+      explain: `This comes from the ${m[1]} package, in its own words.`,
+      fix: 'The package documentation explains its messages. Search for the sentence above together with the package name.'
+    })
+  },
   {
     kind: 'error',
     test: /^LaTeX Error: (.*)/,
     make: (m) => ({ title: tidy(m[1]) })
+  },
+
+  // ---- warnings ----------------------------------------------------------
+  {
+    kind: 'warning',
+    test: /Reference `([^']+)' on page \d+ undefined/,
+    make: (m) => ({
+      title: `No label ${m[1]}`,
+      explain: `Nothing has \\label{${m[1]}}, or it was added after the last run.`,
+      fix: 'Check the spelling, or compile once more so the references settle.',
+      needle: `{${m[1]}}`
+    })
+  },
+  {
+    kind: 'warning',
+    test: /Citation `([^']+)' on page \d+ undefined/,
+    make: (m) => ({
+      title: `No bibliography entry ${m[1]}`,
+      explain: 'No entry with this key was found, or the bibliography wasn\'t processed.',
+      fix: 'Check the key in the .bib file. TeXbrain has no bibtex yet: biblatex documents get a simple bibliography built from the .bib file, classic bibtex needs a .bbl file in the project.',
+      needle: m[1]
+    })
+  },
+  {
+    kind: 'warning',
+    test: /There were undefined (references|citations)/,
+    make: (m) => ({
+      title: `Some ${m[1]} are undefined`,
+      fix: 'Compile once more. If it stays, a \\ref or \\cite points to something that doesn\'t exist.',
+      severity: 'info'
+    })
+  },
+  {
+    kind: 'warning',
+    test: /Label\(s\) may have changed/,
+    make: () => ({
+      title: 'Compile once more',
+      explain: 'Page numbers or references moved during this run, so the numbers in the text are one step behind.',
+      fix: 'Compile again and this goes away.',
+      severity: 'info'
+    })
+  },
+  {
+    kind: 'warning',
+    test: /Label `([^']+)' multiply defined/,
+    make: (m) => ({
+      title: `Label ${m[1]} used twice`,
+      fix: 'Labels have to be unique. Rename one of them.',
+      needle: `\\label{${m[1]}}`
+    })
+  },
+  {
+    kind: 'warning',
+    test: /Font shape `([^']+)' undefined/,
+    make: (m) => ({
+      title: `Font shape ${m[1]} isn't available, a substitute was used`,
+      explain: 'The font family, series or shape doesn\'t exist in this encoding, so LaTeX picked the closest thing.',
+      fix: 'Harmless most of the time. Load the package that provides the font, or use another one.',
+      severity: 'info'
+    })
+  },
+  {
+    kind: 'warning',
+    test: /Some font shapes were not available/,
+    make: () => ({ title: 'Some font shapes were substituted', severity: 'info' })
+  },
+  {
+    kind: 'warning',
+    test: /Token not allowed in a PDF string.*removing `([^']+)'/,
+    make: (m) => ({
+      title: 'A heading has something the PDF bookmarks can\'t show',
+      explain: `hyperref copies headings into the PDF outline, where only plain text works. It dropped the ${m[1]}.`,
+      fix: 'Wrap it: \\texorpdfstring{$x^2$}{x squared}. The first part goes into the document, the second into the bookmarks.'
+    })
+  },
+  {
+    kind: 'warning',
+    test: /File `([^']+)' not found/,
+    make: (m) => fileNotFound(m[1])
+  },
+  {
+    kind: 'warning',
+    test: /Float too large for page/,
+    make: () => ({ title: 'A figure or table is taller than the page', fix: 'Scale it down, or split it.', severity: 'info' })
+  },
+  {
+    kind: 'warning',
+    test: /`!?h' float specifier changed to `!?ht'/,
+    make: () => ({
+      title: 'Float placement relaxed',
+      explain: 'LaTeX couldn\'t put it exactly here and will use the top of a page when it has to.',
+      fix: 'Fine as it is. Use [H] from the float package to force the spot.',
+      severity: 'info'
+    })
+  },
+  {
+    kind: 'warning',
+    test: /Unused global option\(s\):\s*\[([^\]]+)\]/,
+    make: (m) => ({
+      title: `Option ${m[1]} unknown to the class and every package`,
+      fix: 'Check the spelling in \\documentclass[...]. Options are case sensitive.'
+    })
+  },
+  {
+    kind: 'warning',
+    test: /Command (\\\S+) invalid in math mode/,
+    make: (m) => ({
+      title: `${m[1]} doesn't work in math mode`,
+      fix: 'Use the math version, \\mathbf instead of \\bf for example, or leave math mode first.'
+    })
+  },
+  {
+    kind: 'warning',
+    test: /destination with the same identifier \(name\{([^}]+)\}\) has been already used/,
+    make: (m) => ({
+      title: `Two places share the link target ${m[1]}`,
+      explain: 'hyperref links point at identifiers, and this one exists twice, usually a page number that restarts.',
+      fix: 'Use \\frontmatter and \\mainmatter so page numbers don\'t repeat, or \\hypersetup{pageanchor=false} for the pages before the main text.',
+      severity: 'info'
+    })
+  },
+
+  // ---- typesetting notes -------------------------------------------------
+  {
+    kind: 'info',
+    test: /^Overfull \\hbox \(([\d.]+)pt too wide\) in paragraph at lines (\d+)--(\d+)/,
+    make: (m) => ({
+      title: `Text sticks ${Math.round(parseFloat(m[1]))}pt into the margin`,
+      explain: `A word, formula or url on lines ${m[2]} to ${m[3]} is too long to fit and LaTeX found no place to break it.`,
+      fix: 'Add a break hint with \\-, reword the sentence, or wrap urls in \\url. \\sloppy before the paragraph lets LaTeX stretch spaces instead.'
+    })
+  },
+  {
+    kind: 'info',
+    test: /^Overfull \\hbox \(([\d.]+)pt too wide\)/,
+    make: (m) => ({
+      title: `Something sticks ${Math.round(parseFloat(m[1]))}pt into the margin`,
+      fix: 'Usually a table or an image wider than the text. Scale it, or give it a smaller width.'
+    })
+  },
+  {
+    kind: 'info',
+    test: /^Underfull \\hbox \(badness \d+\) in paragraph at lines (\d+)--(\d+)/,
+    make: (m) => ({
+      title: 'A line with stretched spaces',
+      explain: `LaTeX had to pull the spaces on lines ${m[1]} to ${m[2]} apart more than it likes, usually because of a forced line break or a very long word.`,
+      fix: 'Remove a \\\\ or \\newline, or let it be, it only looks a little airy.'
+    })
+  },
+  {
+    kind: 'info',
+    test: /^Underfull \\hbox/,
+    make: () => ({ title: 'A line with stretched spaces', fix: 'Usually a \\\\ in a line that isn\'t full. Harmless.' })
+  },
+  {
+    kind: 'info',
+    test: /^Overfull \\vbox \(([\d.]+)pt too high\)/,
+    make: (m) => ({
+      title: `Content ${Math.round(parseFloat(m[1]))}pt taller than the page`,
+      fix: 'A figure, table or minipage doesn\'t fit the page height. Scale it, or let it float.'
+    })
+  },
+  {
+    kind: 'info',
+    test: /^Underfull \\vbox/,
+    make: () => ({
+      title: 'A page with stretched space',
+      explain: 'LaTeX spread the content of a page to fill it, usually before a forced page break or a large float.',
+      fix: 'Harmless. \\raggedbottom in the preamble stops the stretching.'
+    })
   }
 ];
 

--- a/src/lib/compiler/fixtures/babel-unknown-option.log
+++ b/src/lib/compiler/fixtures/babel-unknown-option.log
@@ -1,0 +1,20 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/babel.sty (/tex/switch.def)
+
+! Package babel Error: Unknown option `brazilx'. Either you misspelled it
+(babel)                or the language definition file brazilx.ldf was not foun
+d.
+
+See the babel package documentation for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.543 \ProcessOptions*
+                      
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/clean.log
+++ b/src/lib/compiler/fixtures/clean.log
@@ -1,0 +1,14 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def) (welcome.aux) [1{/tex/pdftex.ma
+p}] (welcome.aux) )</tex/cmr10.pfb>
+Output written on welcome.pdf (1 page, 11805 bytes).
+Transcript written on welcome.log.
+I found no \citation commands---while reading file welcome.aux
+I found no \bibdata command---while reading file welcome.aux
+I found no \bibstyle command---while reading file welcome.aux
+(There were 3 error messages)

--- a/src/lib/compiler/fixtures/double-subscript.log
+++ b/src/lib/compiler/fixtures/double-subscript.log
@@ -1,0 +1,13 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def)
+No file welcome.aux.
+! Double subscript.
+l.4 $a_b_
+         c$
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/font-shape.log
+++ b/src/lib/compiler/fixtures/font-shape.log
@@ -1,0 +1,22 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def) (welcome.aux)
+
+LaTeX Font Warning: Font shape `OT1/xyz/m/n' undefined
+(Font)              using `OT1/cmr/m/n' instead on input line 4.
+
+[1{/tex/pdftex.map}] (welcome.aux)
+
+LaTeX Font Warning: Some font shapes were not available, defaults substituted.
+
+ )</tex/cmr10.pfb>
+Output written on welcome.pdf (1 page, 10404 bytes).
+Transcript written on welcome.log.
+I found no \citation commands---while reading file welcome.aux
+I found no \bibdata command---while reading file welcome.aux
+I found no \bibstyle command---while reading file welcome.aux
+(There were 3 error messages)

--- a/src/lib/compiler/fixtures/hyperref-token.log
+++ b/src/lib/compiler/fixtures/hyperref-token.log
@@ -1,0 +1,36 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/hyperref.sty (/tex/ltxcmds.sty) (/tex/iftex.sty)
+(/tex/pdftexcmds.sty (/tex/infwarerr.sty)) (/tex/keyval.sty)
+(/tex/kvsetkeys.sty) (/tex/kvdefinekeys.sty) (/tex/pdfescape.sty)
+(/tex/hycolor.sty) (/tex/letltxmacro.sty) (/tex/auxhook.sty)
+(/tex/kvoptions.sty) (/tex/pd1enc.def) (/tex/intcalc.sty) (/tex/etexcmds.sty)
+(/tex/url.sty) (/tex/bitset.sty (/tex/bigintcalc.sty)) (/tex/atbegshi.sty))
+(/tex/hpdftex.def (/tex/atveryend.sty) (/tex/rerunfilecheck.sty
+(/tex/uniquecounter.sty))) (/tex/l3backend-pdfmode.def) (welcome.aux)
+(/tex/nameref.sty (/tex/refcount.sty) (/tex/gettitlestring.sty)) (welcome.out)
+(welcome.out)
+
+Package hyperref Warning: Token not allowed in a PDF string (PDFDocEncoding):
+(hyperref)                removing `math shift' on input line 4.
+
+
+Package hyperref Warning: Token not allowed in a PDF string (PDFDocEncoding):
+(hyperref)                removing `superscript' on input line 4.
+
+
+Package hyperref Warning: Token not allowed in a PDF string (PDFDocEncoding):
+(hyperref)                removing `math shift' on input line 4.
+
+[1{/tex/pdftex.map}] (welcome.aux) )</tex/cmbx12.pfb></tex/cmmi12.pfb></tex/cmr
+10.pfb>
+Output written on welcome.pdf (1 page, 26366 bytes).
+Transcript written on welcome.log.
+I found no \citation commands---while reading file welcome.aux
+I found no \bibdata command---while reading file welcome.aux
+I found no \bibstyle command---while reading file welcome.aux
+(There were 3 error messages)

--- a/src/lib/compiler/fixtures/image-not-found.log
+++ b/src/lib/compiler/fixtures/image-not-found.log
@@ -1,0 +1,27 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/graphicx.sty (/tex/keyval.sty) (/tex/graphics.sty
+(/tex/trig.sty) (/tex/graphics.cfg) (/tex/pdftex.def)))
+(/tex/l3backend-pdfmode.def)
+No file welcome.aux.
+(/tex/supp-pdf.mkii
+[Loading MPS to PDF converter (version 2006.09.02).]
+)
+
+LaTeX Warning: File `nope.jpg' not found on input line 4.
+
+
+! Package pdftex.def Error: File `nope.jpg' not found: using draft setting.
+
+See the pdftex.def package documentation for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.4 \includegraphics{nope.jpg}
+                              
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/mismatched-environment.log
+++ b/src/lib/compiler/fixtures/mismatched-environment.log
@@ -1,0 +1,19 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def)
+No file welcome.aux.
+
+! LaTeX Error: \begin{itemize} on input line 4 ended by \end{enumerate}.
+
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.4 \begin{itemize} \item x \end{enumerate}
+                                           
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/misplaced-ampersand.log
+++ b/src/lib/compiler/fixtures/misplaced-ampersand.log
@@ -1,0 +1,13 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def)
+No file welcome.aux.
+! Misplaced alignment tab character &.
+l.4 a &
+        b
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/missing-dollar.log
+++ b/src/lib/compiler/fixtures/missing-dollar.log
@@ -1,0 +1,15 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def)
+No file welcome.aux.
+! Missing $ inserted.
+<inserted text> 
+                $
+l.4 The value a_
+                b is small.
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/missing-item.log
+++ b/src/lib/compiler/fixtures/missing-item.log
@@ -1,0 +1,19 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def)
+No file welcome.aux.
+
+! LaTeX Error: Something's wrong--perhaps a missing \item.
+
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.4 \begin{itemize} text \end{itemize}
+                                      
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/missing-package.log
+++ b/src/lib/compiler/fixtures/missing-package.log
@@ -1,0 +1,21 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo))
+
+! LaTeX Error: File `doesnotexist.sty' not found.
+
+Type X to quit or <RETURN> to proceed,
+or enter new name. (Default extension: sty)
+
+Enter file name: 
+! Emergency stop.
+<read *> 
+         
+l.3 \begin
+          {document}^^M
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/overfull-hbox.log
+++ b/src/lib/compiler/fixtures/overfull-hbox.log
@@ -1,0 +1,18 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def) (welcome.aux)
+Overfull \hbox (199.279pt too wide) in paragraph at lines 4--5
+[]\OT1/cmr/m/n/10 Averyveryveryveryveryveryveryveryveryveryveryveryveryveryvery
+veryveryveryveryveryveryverylongwordthatcannotbreak
+[1{/tex/pdftex.map}] (welcome.aux) )
+(see the transcript file for additional information)</tex/cmr10.pfb>
+Output written on welcome.pdf (1 page, 14116 bytes).
+Transcript written on welcome.log.
+I found no \citation commands---while reading file welcome.aux
+I found no \bibdata command---while reading file welcome.aux
+I found no \bibstyle command---while reading file welcome.aux
+(There were 3 error messages)

--- a/src/lib/compiler/fixtures/runaway-argument.log
+++ b/src/lib/compiler/fixtures/runaway-argument.log
@@ -1,0 +1,16 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def) (welcome.aux))
+Runaway argument?
+{never closed \end {document} \par 
+! File ended while scanning use of \textbf .
+<inserted text> 
+                \par 
+<*> welcome.tex 
+                
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/text-before-document.log
+++ b/src/lib/compiler/fixtures/text-before-document.log
@@ -1,0 +1,18 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo))
+
+! LaTeX Error: Missing \begin{document}.
+
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.2 h
+     ello
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/too-many-braces.log
+++ b/src/lib/compiler/fixtures/too-many-braces.log
@@ -1,0 +1,12 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def) (welcome.aux)
+! Too many }'s.
+l.4 Hello }
+            there
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/undefined-command.log
+++ b/src/lib/compiler/fixtures/undefined-command.log
@@ -1,0 +1,12 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def) (welcome.aux)
+! Undefined control sequence.
+l.4 Hello \foo
+               world.
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/undefined-environment.log
+++ b/src/lib/compiler/fixtures/undefined-environment.log
@@ -1,0 +1,19 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def)
+No file welcome.aux.
+
+! LaTeX Error: Environment tabularx undefined.
+
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+                                                  
+l.4 \begin{tabularx}
+                    {1cm}{X} a \end{tabularx}
+!  ==> Fatal error occurred, no output PDF file produced!
+Transcript written on welcome.log.

--- a/src/lib/compiler/fixtures/undefined-reference.log
+++ b/src/lib/compiler/fixtures/undefined-reference.log
@@ -1,0 +1,23 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.21 (SwiftLaTeX PDFTeX 0.3.0) (preloaded format=swiftlatexpdftex)
+entering extended mode
+(welcome.tex
+LaTeX2e <2020-02-02> patch level 2
+L3 programming layer <2020-02-14> (/tex/article.cls
+Document Class: article 2020/04/10 v1.4m Standard LaTeX document class
+(/tex/size10.clo)) (/tex/l3backend-pdfmode.def) (welcome.aux)
+
+LaTeX Warning: Reference `nope' on page 1 undefined on input line 4.
+
+
+LaTeX Warning: Citation `nokey' on page 1 undefined on input line 4.
+
+[1{/tex/pdftex.map}] (welcome.aux)
+
+LaTeX Warning: There were undefined references.
+
+ )</tex/cmbx10.pfb></tex/cmr10.pfb>
+Output written on welcome.pdf (1 page, 20571 bytes).
+Transcript written on welcome.log.
+I found no \bibdata command---while reading file welcome.aux
+I found no \bibstyle command---while reading file welcome.aux
+(There were 2 error messages)

--- a/src/lib/compiler/log.test.ts
+++ b/src/lib/compiler/log.test.ts
@@ -1,0 +1,136 @@
+// the fixtures are real transcripts from the engine, one per kind of
+// mistake, compiled through the app itself
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'vitest';
+import { parseLog, locateByNeedle } from './log';
+
+function fixture(name: string): string {
+  return readFileSync(new URL(`./fixtures/${name}.log`, import.meta.url), 'utf8');
+}
+
+function problemsOf(name: string) {
+  return parseLog(fixture(name)).problems;
+}
+
+describe('parseLog', () => {
+  test('a clean run has no problems', () => {
+    expect(problemsOf('clean')).toEqual([]);
+  });
+
+  test('an unknown command names the command and the spot', () => {
+    const [p, ...rest] = problemsOf('undefined-command');
+    expect(rest).toEqual([]);
+    expect(p.severity).toBe('error');
+    expect(p.title).toBe('Unknown command \\foo');
+    expect(p.file).toBe('welcome.tex');
+    expect(p.inPackage).toBe(false);
+    expect(p.line).toBe(4);
+    expect(p.context).toEqual({ before: 'Hello \\foo', after: 'world.' });
+    expect(p.excerpt[0]).toBe('! Undefined control sequence.');
+  });
+
+  test('the fatal summary and the emergency stop are not problems of their own', () => {
+    const p = problemsOf('missing-package');
+    expect(p).toHaveLength(1);
+    expect(p[0].title).toBe('Package doesnotexist not found');
+    expect(p[0].line).toBeUndefined();
+    expect(p[0].needle).toBe('doesnotexist');
+  });
+
+  test('a missing package is placed by searching the sources', () => {
+    const problems = problemsOf('missing-package');
+    locateByNeedle(problems, new Map([['welcome.tex', '\\documentclass{article}\n\\usepackage{doesnotexist}\n\\begin{document}\nHello.\n\\end{document}\n']]));
+    expect(problems[0].file).toBe('welcome.tex');
+    expect(problems[0].line).toBe(2);
+  });
+
+  test('messages that wrap at 79 characters are glued back together', () => {
+    const [p] = problemsOf('babel-unknown-option');
+    expect(p.title).toBe('babel doesn\'t know the language brazilx');
+    expect(p.message).toContain('brazilx.ldf was not found');
+    expect(p.file).toBe('babel.sty');
+    expect(p.inPackage).toBe(true);
+    expect(p.line).toBe(543);
+  });
+
+  test('math outside math mode shows where tex stopped reading', () => {
+    const [p] = problemsOf('missing-dollar');
+    expect(p.title).toBe('Math outside math mode');
+    expect(p.context).toEqual({ before: 'The value a_', after: 'b is small.' });
+  });
+
+  test('a runaway argument has no line but explains itself', () => {
+    const [p] = problemsOf('runaway-argument');
+    expect(p.title).toBe('Something was never closed');
+    expect(p.line).toBeUndefined();
+    expect(p.excerpt[0]).toBe('Runaway argument?');
+    expect(p.explain).toContain('\\textbf');
+  });
+
+  test('undefined references become warnings, the summary line does not', () => {
+    const p = problemsOf('undefined-reference');
+    expect(p.map(x => [x.severity, x.title])).toEqual([
+      ['warning', 'No label nope'],
+      ['warning', 'No bibliography entry nokey']
+    ]);
+    expect(p[0].needle).toBe('{nope}');
+    expect(p[0].line).toBe(4);
+  });
+
+  test('a missing image is one error, not an error and a warning', () => {
+    const p = problemsOf('image-not-found');
+    expect(p).toHaveLength(1);
+    expect(p[0].severity).toBe('error');
+    expect(p[0].title).toBe('Image nope.jpg not found');
+    expect(p[0].line).toBe(4);
+  });
+
+  test('the same complaint about the same line collapses into one card', () => {
+    const p = problemsOf('hyperref-token');
+    expect(p).toHaveLength(1);
+    expect(p[0].count).toBe(3);
+    expect(p[0].title).toBe('A heading has something the PDF bookmarks can\'t show');
+  });
+
+  test('boxes are notes with the line they start on', () => {
+    const [p] = problemsOf('overfull-hbox');
+    expect(p.severity).toBe('info');
+    expect(p.title).toBe('Text sticks 199pt into the margin');
+    expect(p.line).toBe(4);
+  });
+
+  test('font substitutions are notes and the summary is dropped', () => {
+    const p = problemsOf('font-shape');
+    expect(p).toHaveLength(1);
+    expect(p[0].severity).toBe('info');
+    expect(p[0].title).toContain('OT1/xyz/m/n');
+  });
+
+  test.each([
+    ['double-subscript', 'Two _ in a row'],
+    ['misplaced-ampersand', '& outside a table'],
+    ['missing-item', 'Missing \\item'],
+    ['mismatched-environment', '\\begin{itemize} closed by \\end{enumerate}'],
+    ['undefined-environment', 'Unknown environment tabularx'],
+    ['text-before-document', 'Text before \\begin{document}'],
+    ['too-many-braces', 'Braces don\'t add up']
+  ])('%s reads as "%s"', (name, title) => {
+    const p = problemsOf(name);
+    expect(p).toHaveLength(1);
+    expect(p[0].severity).toBe('error');
+    expect(p[0].title).toBe(title);
+    expect(p[0].line).toBeGreaterThan(0);
+  });
+
+  test('the unknown environment points at the package', () => {
+    const [p] = problemsOf('undefined-environment');
+    expect(p.fix).toContain('\\usepackage{tabularx}');
+  });
+
+  test('the cleaned log drops file noise but keeps the errors', () => {
+    const { cleanedLines } = parseLog(fixture('undefined-command'));
+    expect(cleanedLines).toContain('! Undefined control sequence.');
+    expect(cleanedLines.some(l => l.startsWith('(/tex/'))).toBe(false);
+  });
+});

--- a/src/lib/compiler/log.test.ts
+++ b/src/lib/compiler/log.test.ts
@@ -3,7 +3,7 @@
 
 import { readFileSync } from 'node:fs';
 import { describe, expect, test } from 'vitest';
-import { parseLog, locateByNeedle, problemText, problemsReport } from './log';
+import { parseLog, locateByNeedle, problemText, problemsReport, looksLikeOurs, issueUrl } from './log';
 
 function fixture(name: string): string {
   return readFileSync(new URL(`./fixtures/${name}.log`, import.meta.url), 'utf8');
@@ -141,6 +141,15 @@ describe('parseLog', () => {
     const report = problemsReport(problemsOf('undefined-reference'), 'main.tex');
     expect(report.split('\n')[0]).toBe('TeXbrain problems for main.tex (2 warnings)');
     expect(report).toContain('WARNING  welcome.tex, line 4: No label nope');
+  });
+
+  test('a missing package is worth an issue, a typo is not', () => {
+    expect(looksLikeOurs(problemsOf('missing-package')[0])).toBe(true);
+    expect(looksLikeOurs(problemsOf('babel-unknown-option')[0])).toBe(true);
+    expect(looksLikeOurs(problemsOf('undefined-command')[0])).toBe(false);
+    const url = new URL(issueUrl(problemsOf('missing-package')[0], 'main.tex'));
+    expect(url.searchParams.get('title')).toBe('Package doesnotexist not found');
+    expect(url.searchParams.get('body')).toContain('ERROR  welcome.tex: Package doesnotexist not found');
   });
 
   test('the cleaned log drops file noise but keeps the errors', () => {

--- a/src/lib/compiler/log.test.ts
+++ b/src/lib/compiler/log.test.ts
@@ -3,7 +3,7 @@
 
 import { readFileSync } from 'node:fs';
 import { describe, expect, test } from 'vitest';
-import { parseLog, locateByNeedle } from './log';
+import { parseLog, locateByNeedle, problemText, problemsReport } from './log';
 
 function fixture(name: string): string {
   return readFileSync(new URL(`./fixtures/${name}.log`, import.meta.url), 'utf8');
@@ -126,6 +126,21 @@ describe('parseLog', () => {
   test('the unknown environment points at the package', () => {
     const [p] = problemsOf('undefined-environment');
     expect(p.fix).toContain('\\usepackage{tabularx}');
+  });
+
+  test('a problem as text has the headline, the advice, the spot and the log lines', () => {
+    const [p] = problemsOf('undefined-command');
+    const text = problemText(p);
+    expect(text.split('\n')[0]).toBe('ERROR  welcome.tex, line 4: Unknown command \\foo');
+    expect(text).toContain('Try: Check the spelling');
+    expect(text).toContain('> Hello \\foo|world.');
+    expect(text).toContain('! Undefined control sequence.');
+  });
+
+  test('the report counts what it contains', () => {
+    const report = problemsReport(problemsOf('undefined-reference'), 'main.tex');
+    expect(report.split('\n')[0]).toBe('TeXbrain problems for main.tex (2 warnings)');
+    expect(report).toContain('WARNING  welcome.tex, line 4: No label nope');
   });
 
   test('the cleaned log drops file noise but keeps the errors', () => {

--- a/src/lib/compiler/log.ts
+++ b/src/lib/compiler/log.ts
@@ -162,10 +162,11 @@ export function parseLog(rawLog: string): ParsedLog {
     return { text: u.text.replace(/^\([\w.-]+\)\s{2,}/, ''), end: u.end };
   }
 
+  // the same complaint about the same spot, from a second pass or a
+  // second token on the line, becomes one card with a count
   function push(p: Omit<Problem, 'count'>) {
     const same = problems.find(q =>
-      q.severity === p.severity && q.title === p.title && q.message === p.message &&
-      q.file === p.file && q.line === p.line
+      q.severity === p.severity && q.title === p.title && q.file === p.file && q.line === p.line
     );
     if (same) { same.count++; return; }
     problems.push({ ...p, count: 1 });

--- a/src/lib/compiler/log.ts
+++ b/src/lib/compiler/log.ts
@@ -1,17 +1,40 @@
-// turns a pdftex log into something the errors and warnings tabs can show,
-// and a cleaned copy for the log tab without the file open/close noise
+// turns a pdftex transcript into problems a person can act on, plus a
+// cleaned copy of the log for reading. the raw transcript is kept elsewhere
 
-export interface LogEntry {
-  type: 'error' | 'warning';
+import { explain, type Explanation } from './explain';
+
+export type Severity = 'error' | 'warning' | 'info';
+
+export interface Problem {
+  severity: Severity;
+  // plain words, the headline of the card
+  title: string;
+  // what tex actually said, prefixes stripped
   message: string;
-  line?: number;
+  explain?: string;
+  fix?: string;
+  // as printed by tex, with ./ and /tex/ stripped, so main.tex or babel.sty
   file?: string;
+  // true when the file came out of the tex live tree, not the project
+  inPackage: boolean;
+  line?: number;
+  // something to search the sources for when tex gave no line
+  needle?: string;
+  // the source line where tex stopped reading, split at that spot
+  context?: { before: string; after: string };
+  // the raw log lines this came from
+  excerpt: string[];
+  count: number;
 }
 
 export interface ParsedLog {
-  errors: LogEntry[];
+  problems: Problem[];
   cleanedLines: string[];
 }
+
+// tex breaks its lines at exactly this many characters and continues on the
+// next one, mid word if it has to
+const WRAP = 79;
 
 const NOISE = [
   /^\s*\(\/tex\//,
@@ -24,20 +47,39 @@ const NOISE = [
   /^ABD: Every/,
   /^\*geometry\*/,
   /^1773\d+/,
-  /^\s*$/
+  /^\s*$/,
+  /^No file .*\.(aux|toc|lof|lot|out|nav|snm|bbl)\.$/,
+  /^I found no \\(citation|bibdata|bibstyle) command/,
+  /^\(There (was|were) \d+ error messages?\)$/,
+  /^\(see the transcript file for additional information\)$/
+];
+
+// lines tex prints for an interactive user, meaningless in batch mode
+const HELP_LINES = [
+  /^See the .* for explanation\.$/,
+  /^Type  H <return>  for immediate help\.$/,
+  /^ \.\.\.\s*$/,
+  /^Type X to quit or <RETURN> to proceed,$/,
+  /^or enter new name\. \(Default extension: \w+\)$/,
+  /^Enter file name:\s*$/
 ];
 
 const SUPPRESSED_WARNINGS = [
   /shell escape.*disabled/i,
   /You have requested package/,
   /You have requested, on input line.*version/,
-  /^(Underfull|Overfull)\s+\\[hv]box/,
   /pdfTeX warning:.*PDF inclusion: found PDF/,
   /ABD: EveryShipout/
 ];
 
-function isSuppressedWarning(msg: string): boolean {
-  return SUPPRESSED_WARNINGS.some(p => p.test(msg));
+const IMAGE_EXT = /\.(png|jpe?g|pdf|eps|gif|bmp|tiff?|svg)$/i;
+
+function isHelpLine(line: string): boolean {
+  return HELP_LINES.some(p => p.test(line));
+}
+
+function stripPrefix(path: string): string {
+  return path.replace(/^(\.\/|\/work\/|\/tex\/)/, '');
 }
 
 // the log panel renders one element per line, huge logs freeze the ui
@@ -51,15 +93,33 @@ export function capLogLines(lines: string[], max = 800): string[] {
   ];
 }
 
+// fills in lines for problems tex could not place, by searching the
+// sources for what the problem is about (a package name, a label, ...)
+export function locateByNeedle(problems: Problem[], files: Map<string, string>): void {
+  for (const p of problems) {
+    if (p.line !== undefined || !p.needle) continue;
+    for (const [path, content] of files) {
+      if (!path.toLowerCase().endsWith('.tex')) continue;
+      const lines = content.split('\n');
+      const idx = lines.findIndex(l => l.includes(p.needle!));
+      if (idx >= 0) {
+        p.file = path;
+        p.inPackage = false;
+        p.line = idx + 1;
+        break;
+      }
+    }
+  }
+}
+
 export function parseLog(rawLog: string): ParsedLog {
-  const errors: LogEntry[] = [];
-  const lines = rawLog.split('\n');
+  const lines = rawLog.replace(/\r/g, '').split('\n');
   const cleanedLines: string[] = [];
+  const problems: Problem[] = [];
 
   // pdftex prints "(<path>" when it opens a file and ")" when it closes it
-  // again. following that gives every error the file it happened in, which
-  // is the difference between "line 39" and "line 39 of hyperref.sty". the
-  // log wraps long lines, so this stays a best effort
+  // again. following that gives every problem the file it happened in. long
+  // lines wrap, so this stays a best effort
   const openFiles: string[] = [];
   function trackOpenFiles(text: string) {
     let skipped = 0;
@@ -76,66 +136,241 @@ export function parseLog(rawLog: string): ParsedLog {
       }
     }
   }
-  function currentFile(): string | undefined {
+  function currentFile(): { file?: string; inPackage: boolean } {
     const path = openFiles[openFiles.length - 1];
-    return path?.replace(/^(\.\/|\/work\/|\/tex\/)/, '');
+    if (!path) return { inPackage: false };
+    return { file: stripPrefix(path), inPackage: path.startsWith('/tex/') };
   }
-  let afterContext = false;
 
-  for (let i = 0; i < lines.length; i++) {
+  // reads one logical line starting at i, gluing wrapped continuations back
+  // together. returns the text and the index of the last physical line used
+  function unwrap(i: number): { text: string; end: number } {
+    let text = lines[i];
+    let end = i;
+    while (lines[end].length === WRAP && end + 1 < lines.length && lines[end + 1].length > 0) {
+      end++;
+      text += lines[end];
+    }
+    return { text, end };
+  }
+
+  // "(babel)        the rest of the message" continuation lines
+  function continuation(i: number): { text: string; end: number } | null {
+    const m = lines[i]?.match(/^\(([\w.-]+)\)\s{2,}(.*)$/);
+    if (!m) return null;
+    const u = unwrap(i);
+    return { text: u.text.replace(/^\([\w.-]+\)\s{2,}/, ''), end: u.end };
+  }
+
+  function push(p: Omit<Problem, 'count'>) {
+    const same = problems.find(q =>
+      q.severity === p.severity && q.title === p.title && q.message === p.message &&
+      q.file === p.file && q.line === p.line
+    );
+    if (same) { same.count++; return; }
+    problems.push({ ...p, count: 1 });
+  }
+
+  function decorate(base: Omit<Problem, 'count' | 'title'>, ex: Explanation): Omit<Problem, 'count'> {
+    return { ...base, title: ex.title, explain: ex.explain, fix: ex.fix, needle: ex.needle };
+  }
+
+  let sawRealError = false;
+  let stopExcerpt: string[] | null = null;
+  let stopLocation: { file?: string; inPackage: boolean; line?: number } = { inPackage: false };
+
+  let i = 0;
+  while (i < lines.length) {
     const line = lines[i];
     const trimmed = line.trim();
 
+    // ---- errors --------------------------------------------------------
     if (trimmed.startsWith('! ')) {
-      const msg = trimmed.slice(2);
+      const head = unwrap(i);
+      let message = head.text.trim().slice(2).trim();
+      let end = head.end;
+      const excerpt: string[] = [];
+
+      // "Runaway argument?" and the runaway text sit right above the error
+      if (i >= 2 && lines[i - 2] === 'Runaway argument?') {
+        excerpt.push(lines[i - 2], lines[i - 1]);
+      } else if (i >= 1 && lines[i - 1] === 'Runaway argument?') {
+        excerpt.push(lines[i - 1]);
+      }
+      for (let k = i; k <= end; k++) excerpt.push(lines[k]);
+
+      // message lines that continue with a (package) prefix
+      let j = end + 1;
+      while (j < lines.length) {
+        const c = continuation(j);
+        if (!c) break;
+        message += ' ' + c.text.trim();
+        for (let k = j; k <= c.end; k++) excerpt.push(lines[k]);
+        j = c.end + 1;
+      }
+
+      // the fatal summary is a consequence of the errors above, not a problem
+      if (/^==> Fatal error occurred/.test(message)) {
+        cleanedLines.push(line);
+        i = end + 1;
+        continue;
+      }
+
+      // where tex stopped reading: "l.12 before" and the rest on the next line
       let lineNum: number | undefined;
-      for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
-        const m = lines[j].match(/^l\.(\d+)/);
-        if (m) { lineNum = parseInt(m[1], 10); break; }
+      let context: Problem['context'];
+      let k = j;
+      while (k < lines.length && k < j + 14 && !lines[k].trim().startsWith('! ')) {
+        const lm = lines[k].match(/^l\.(\d+) ?(.*)$/);
+        if (lm) {
+          lineNum = parseInt(lm[1], 10);
+          const before = lm[2];
+          const after = (lines[k + 1] ?? '').replace(/^\s+/, '');
+          context = { before, after };
+          for (let x = j; x <= k + 1 && x < lines.length; x++) {
+            if (!isHelpLine(lines[x]) && lines[x].trim() !== '') excerpt.push(lines[x]);
+          }
+          k = k + 1;
+          break;
+        }
+        if (/^<\*> /.test(lines[k])) {
+          for (let x = j; x <= k; x++) {
+            if (!isHelpLine(lines[x]) && lines[x].trim() !== '') excerpt.push(lines[x]);
+          }
+          break;
+        }
+        k++;
       }
-      errors.push({ type: 'error', message: msg, line: lineNum, file: currentFile() });
-      cleanedLines.push(line);
+      const consumedTo = lineNum !== undefined ? k : end;
+
+      const where = currentFile();
+      if (/^Emergency stop\.?$/.test(message)) {
+        // only worth a card when nothing else explains the stop
+        stopExcerpt = excerpt;
+        stopLocation = { ...where, line: lineNum };
+      } else {
+        sawRealError = true;
+        const base = { severity: 'error' as const, message, file: where.file, inPackage: where.inPackage, line: lineNum, context, excerpt };
+        push(decorate(base, explain('error', message, { before: context?.before, file: where.file, inPackage: where.inPackage })));
+      }
+
+      for (let x = i; x <= consumedTo && x < lines.length; x++) {
+        if (!isHelpLine(lines[x]) && lines[x].trim() !== '') cleanedLines.push(lines[x]);
+      }
+      i = consumedTo + 1;
       continue;
     }
 
-    if (/LaTeX Warning:/i.test(trimmed) || /Package \w+ Warning:/i.test(trimmed)) {
-      const warnMatch = trimmed.match(/Warning:\s*(.+)/i);
-      const msg = warnMatch ? warnMatch[1] : trimmed;
-      if (!isSuppressedWarning(trimmed) && !isSuppressedWarning(msg)) {
-        let lineNum: number | undefined;
-        const lm = trimmed.match(/on input line (\d+)/);
-        if (lm) lineNum = parseInt(lm[1], 10);
-        errors.push({ type: 'warning', message: msg.replace(/\s+$/, ''), line: lineNum, file: currentFile() });
+    // ---- warnings ------------------------------------------------------
+    const warnHead = trimmed.match(/^(LaTeX Warning|LaTeX Font Warning|Package [\w.-]+ Warning|Class [\w.-]+ Warning):\s*(.*)$/);
+    if (warnHead) {
+      const head = unwrap(i);
+      let message = head.text.trim().replace(/^[^:]+:\s*/, '');
+      let end = head.end;
+      const excerpt: string[] = [];
+      for (let k = i; k <= end; k++) excerpt.push(lines[k]);
+      let j = end + 1;
+      while (j < lines.length) {
+        const c = continuation(j);
+        if (!c) break;
+        message += ' ' + c.text.trim();
+        for (let k = j; k <= c.end; k++) excerpt.push(lines[k]);
+        j = c.end + 1;
       }
-      cleanedLines.push(line);
+      message = message.replace(/\s+/g, ' ').trim();
+
+      if (!SUPPRESSED_WARNINGS.some(p => p.test(message))) {
+        const lm = message.match(/on input line (\d+)/);
+        const where = currentFile();
+        const ex = explain('warning', message, { file: where.file, inPackage: where.inPackage });
+        push(decorate({
+          severity: ex.severity ?? 'warning',
+          message,
+          file: where.file,
+          inPackage: where.inPackage,
+          line: lm ? parseInt(lm[1], 10) : undefined,
+          excerpt
+        }, ex));
+      }
+      for (let x = i; x < j; x++) cleanedLines.push(lines[x]);
+      i = j;
       continue;
     }
 
-    if (/pdfTeX warning:/i.test(trimmed) && !/fontmap entry/.test(trimmed)) {
-      if (!isSuppressedWarning(trimmed)) {
-        errors.push({ type: 'warning', message: trimmed });
+    if (/pdfTeX warning/i.test(trimmed) && !/fontmap entry/.test(trimmed)) {
+      const head = unwrap(i);
+      const message = head.text.trim();
+      if (!SUPPRESSED_WARNINGS.some(p => p.test(message))) {
+        const where = currentFile();
+        const ex = explain('warning', message, { file: where.file, inPackage: where.inPackage });
+        push(decorate({ severity: ex.severity ?? 'warning', message, file: where.file, inPackage: where.inPackage, excerpt: [message] }, ex));
       }
-      cleanedLines.push(line);
+      for (let x = i; x <= head.end; x++) cleanedLines.push(lines[x]);
+      i = head.end + 1;
       continue;
     }
 
-    if (/^(Underfull|Overfull)\s+\\[hv]box/.test(trimmed)) {
-      cleanedLines.push(line);
+    // ---- boxes: layout notes, not mistakes ------------------------------
+    const box = trimmed.match(/^(Overfull|Underfull) \\[hv]box .*(?:at lines (\d+)--(\d+)|detected at line (\d+)|while \\output is active)/);
+    if (box) {
+      const excerpt = [line];
+      let j = i + 1;
+      // the box contents follow until a blank line or a page marker
+      while (j < lines.length && lines[j].trim() !== '' && !/^\[/.test(lines[j]) && !/^(Overfull|Underfull)/.test(lines[j]) && !lines[j].startsWith('! ') && !/Warning:/.test(lines[j])) {
+        excerpt.push(lines[j]);
+        j++;
+      }
+      const where = currentFile();
+      const ex = explain('info', trimmed, { file: where.file, inPackage: where.inPackage });
+      const at = box[2] ?? box[4];
+      push(decorate({
+        severity: 'info',
+        message: trimmed,
+        file: where.file,
+        inPackage: where.inPackage,
+        line: at ? parseInt(at, 10) : undefined,
+        excerpt
+      }, ex));
+      for (let x = i; x < j; x++) cleanedLines.push(lines[x]);
+      i = j;
       continue;
     }
 
     // the "l.39 ..." context after an error quotes source, which can
-    // contain parentheses of its own, so it is left out of the tracking
-    const isContext = /^l\.\d+/.test(trimmed);
-    if (!isContext && !afterContext) trackOpenFiles(line);
-    afterContext = isContext;
+    // contain parentheses of its own, so it stays out of the tracking
+    if (!/^l\.\d+/.test(trimmed) && !/^Runaway argument\?/.test(trimmed)) trackOpenFiles(line);
 
-    if (NOISE.some(p => p.test(trimmed))) continue;
-    if (/^[\s()]*$/.test(trimmed)) continue;
-    if (/^[\s()]*(\([^)]*\)[\s)]*)+[\s)]*$/.test(trimmed)) continue;
+    if (NOISE.some(p => p.test(trimmed))) { i++; continue; }
+    if (/^[\s()]*$/.test(trimmed)) { i++; continue; }
+    if (/^[\s()]*(\([^)]*\)[\s)]*)+[\s)]*$/.test(trimmed)) { i++; continue; }
 
     cleanedLines.push(line);
+    i++;
   }
 
-  return { errors, cleanedLines };
+  // an emergency stop only says something when no error explains it
+  if (!sawRealError && stopExcerpt) {
+    const base = { severity: 'error' as const, message: 'Emergency stop.', file: stopLocation.file, inPackage: stopLocation.inPackage, line: stopLocation.line, excerpt: stopExcerpt };
+    push(decorate(base, explain('error', 'Emergency stop.', { file: stopLocation.file, inPackage: stopLocation.inPackage })));
+  }
+
+  // summaries that repeat what the individual problems already say
+  const hasUndefinedRef = problems.some(p => /Reference `|Citation `/.test(p.message));
+  const hasFontShape = problems.some(p => /Font shape `/.test(p.message));
+  const notFoundErrors = new Set(problems.filter(p => p.severity === 'error').map(p => p.message.match(/File `([^']+)' not found/)?.[1]).filter(Boolean));
+  const kept = problems.filter(p => {
+    if (hasUndefinedRef && /There were undefined (references|citations)/.test(p.message)) return false;
+    if (hasFontShape && /Some font shapes were not available/.test(p.message)) return false;
+    if (p.severity === 'warning') {
+      const f = p.message.match(/File `([^']+)' not found/)?.[1];
+      if (f && notFoundErrors.has(f)) return false;
+    }
+    return true;
+  });
+
+  return { problems: kept, cleanedLines };
+}
+
+export function isImageFile(name: string): boolean {
+  return IMAGE_EXT.test(name);
 }

--- a/src/lib/compiler/log.ts
+++ b/src/lib/compiler/log.ts
@@ -375,3 +375,26 @@ export function parseLog(rawLog: string): ParsedLog {
 export function isImageFile(name: string): boolean {
   return IMAGE_EXT.test(name);
 }
+
+const LABEL = { error: 'ERROR', warning: 'WARNING', info: 'NOTE' };
+
+// one problem as plain text, for pasting into an issue or a chat
+export function problemText(p: Problem): string {
+  const where = [p.file ? (p.inPackage ? `${p.file} (package)` : p.file) : '', p.line ? `line ${p.line}` : ''].filter(Boolean).join(', ');
+  const out = [`${LABEL[p.severity]}${where ? '  ' + where : ''}: ${p.title}${p.count > 1 ? ` (x${p.count})` : ''}`];
+  if (p.explain) out.push(`  ${p.explain}`);
+  if (p.fix) out.push(`  Try: ${p.fix}`);
+  if (p.context && (p.context.before || p.context.after)) out.push(`  > ${p.context.before}|${p.context.after}`);
+  if (p.excerpt.length > 0) out.push(...p.excerpt.map(l => `  ${l}`));
+  else if (p.message !== p.title) out.push(`  ${p.message}`);
+  return out.join('\n');
+}
+
+export function problemsReport(problems: Problem[], mainFile: string): string {
+  const count = (s: Severity, word: string) => {
+    const n = problems.filter(p => p.severity === s).length;
+    return n > 0 ? `${n} ${word}${n === 1 ? '' : 's'}` : '';
+  };
+  const summary = [count('error', 'error'), count('warning', 'warning'), count('info', 'note')].filter(Boolean).join(', ') || 'no problems';
+  return [`TeXbrain problems for ${mainFile} (${summary})`, '', ...problems.map(problemText)].join('\n\n').replace(/\n\n\n/g, '\n\n');
+}

--- a/src/lib/compiler/log.ts
+++ b/src/lib/compiler/log.ts
@@ -390,6 +390,41 @@ export function problemText(p: Problem): string {
   return out.join('\n');
 }
 
+// problems that point at the app rather than the document: a package the
+// mirror should have, a font that didn't load, or an error deep inside a
+// package with no obvious cause
+export function looksLikeOurs(p: Problem): boolean {
+  if (p.severity !== 'error') return false;
+  return p.inPackage || /^(Package|Class) \S+ not found|couldn't be loaded|^The compile stopped here|^TeX ran out of room/.test(p.title);
+}
+
+// a github issue with the compile template, the problem already filled in
+export function issueUrl(p: Problem, mainFile: string): string {
+  const body = [
+    '**What did you compile?**',
+    '',
+    `Main file: ${mainFile}. A minimal document that shows it:`,
+    '',
+    '```latex',
+    '',
+    '```',
+    '',
+    '**What did TeXbrain say?**',
+    '',
+    '```',
+    problemText(p),
+    '```',
+    '',
+    'Full log: Log tab, Download, attached here.',
+    '',
+    '**Browser, and how you opened the project**',
+    '',
+    typeof navigator !== 'undefined' ? navigator.userAgent : ''
+  ].join('\n');
+  const params = new URLSearchParams({ template: 'compile.md', labels: 'compile', title: p.title, body });
+  return `https://github.com/swimmingbrain/texbrain/issues/new?${params.toString()}`;
+}
+
 export function problemsReport(problems: Problem[], mainFile: string): string {
   const count = (s: Severity, word: string) => {
     const n = problems.filter(p => p.severity === s).length;

--- a/src/lib/editor/setup.ts
+++ b/src/lib/editor/setup.ts
@@ -131,6 +131,17 @@ export function replaceEditorContent(view: EditorView, content: string) {
   });
 }
 
+// puts the cursor at the start of a line and scrolls it into the middle
+export function gotoLine(view: EditorView, line: number) {
+  const n = Math.max(1, Math.min(line, view.state.doc.lines));
+  const pos = view.state.doc.line(n).from;
+  view.dispatch({
+    selection: { anchor: pos },
+    effects: EditorView.scrollIntoView(pos, { y: 'center' })
+  });
+  view.focus();
+}
+
 export function insertAtCursor(view: EditorView, text: string) {
   const cursor = view.state.selection.main.head;
   const cursorPlaceholder = text.indexOf('|');

--- a/src/lib/editor/setup.ts
+++ b/src/lib/editor/setup.ts
@@ -21,6 +21,8 @@ export interface EditorConfig {
   parent: HTMLElement;
   dark: boolean;
   onUpdate?: (content: string) => void;
+  // fires on every cursor move, edits included
+  onCursor?: (line: number, col: number) => void;
   // pass the result of yCollab(...) here to enable collaborative editing
   collab?: Extension;
 }
@@ -55,6 +57,11 @@ export function createEditor(config: EditorConfig): EditorView {
   const updateListener = EditorView.updateListener.of((update) => {
     if (update.docChanged && config.onUpdate) {
       config.onUpdate(update.state.doc.toString());
+    }
+    if ((update.selectionSet || update.docChanged) && config.onCursor) {
+      const pos = update.state.selection.main.head;
+      const line = update.state.doc.lineAt(pos);
+      config.onCursor(line.number, pos - line.from + 1);
     }
   });
 

--- a/src/lib/project/manager.ts
+++ b/src/lib/project/manager.ts
@@ -391,6 +391,12 @@ function findFileByPath(tree: TreeEntry[], path: string): TreeEntry | null {
   return null;
 }
 
+// a path as the compiler printed it, or just a file name, to a tree entry
+export function findProjectFile(path: string): TreeEntry | null {
+  const tree = get(projectTree);
+  return findFileByPath(tree, path) || findFileInTree(tree, path.split('/').pop() || path);
+}
+
 function findFileInTree(tree: TreeEntry[], name: string): TreeEntry | null {
   for (const entry of tree) {
     if (entry.type === 'file' && entry.name === name) return entry;

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -1,16 +1,17 @@
 import { writable, derived } from 'svelte/store';
+import type { Problem } from '$lib/compiler/log';
 
 export const sidebarOpen = writable(true);
 export const previewOpen = writable(true);
 export const snippetPickerOpen = writable(false);
 export const commandPaletteOpen = writable(false);
 export const cloneDialogOpen = writable(false);
-export const previewTab = writable<'preview' | 'errors' | 'warnings' | 'log'>('preview');
+export const previewTab = writable<'preview' | 'problems' | 'log'>('preview');
 export const compileStatus = writable<'idle' | 'compiling' | 'success' | 'error'>('idle');
 export const compileLog = writable<string[]>([]);
 // everything the engine printed, untouched, for the people who want it all
 export const compileRawLog = writable('');
-export const compileErrors = writable<Array<{ type: 'error' | 'warning'; message: string; line?: number; file?: string }>>([]);
+export const compileProblems = writable<Problem[]>([]);
 export const toasts = writable<Array<{ id: string; message: string; type: 'info' | 'success' | 'warning' | 'error' }>>([]);
 
 let toastId = 0;

--- a/src/lib/ui/LogPanel.svelte
+++ b/src/lib/ui/LogPanel.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { addToast } from '$lib/stores/app';
+
+  // everything the engine printed
+  export let raw = '';
+  // the same without the file noise, one entry per line
+  export let cleaned: string[] = [];
+  export let fileName = 'document.log';
+
+  // the panel renders one element per line, so very long logs are cut and
+  // the download has the rest
+  const MAX = 3000;
+
+  let full = false;
+  let query = '';
+
+  $: lines = full ? raw.replace(/\r/g, '').split('\n') : cleaned;
+  $: numbered = lines.map((text, i) => ({ n: i + 1, text }));
+  $: shown = query.trim()
+    ? numbered.filter(l => l.text.toLowerCase().includes(query.trim().toLowerCase()))
+    : numbered;
+
+  type Kind = 'error' | 'warning' | 'context' | 'box' | 'file' | 'page' | 'ok' | 'meta' | '';
+
+  // a little color goes a long way in a wall of text
+  function kind(text: string): Kind {
+    if (/^\[\d{1,2}:\d{2}:\d{2}/.test(text)) return 'meta';
+    if (text.startsWith('!')) return 'error';
+    if (/Warning:/.test(text) || /^\([\w.-]+\)\s{2,}/.test(text)) return 'warning';
+    if (/^l\.\d+/.test(text) || /^<(inserted text|to be read again|\*|argument)>/.test(text)) return 'context';
+    if (/^(Overfull|Underfull) \\[hv]box/.test(text)) return 'box';
+    if (/^\s*[()]/.test(text) || /\(\/tex\//.test(text) || /^\s*<\/tex\//.test(text)) return 'file';
+    if (/^\[\d+/.test(text)) return 'page';
+    if (/^Output written|compilation successful/.test(text)) return 'ok';
+    return '';
+  }
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(raw);
+      addToast('Log copied', 'success', 1500);
+    } catch {
+      addToast('Could not copy, use download instead', 'error');
+    }
+  }
+
+  function download() {
+    const blob = new Blob([raw], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<div class="log">
+  <div class="toolbar">
+    <button class="log-btn" class:active={full} on:click={() => (full = !full)} aria-pressed={full} title="Everything the engine printed, nothing filtered">Full log</button>
+    <input class="search" type="search" placeholder="Search" bind:value={query} aria-label="Search the log" spellcheck="false" />
+    <span class="meta" aria-live="polite">{query.trim() ? `${shown.length} of ${lines.length}` : `${lines.length}`} lines</span>
+    <button class="log-btn" on:click={copy} disabled={!raw} title="Copy the full log to the clipboard">Copy</button>
+    <button class="log-btn" on:click={download} disabled={!raw} title="Download the full log as a file">Download</button>
+  </div>
+  {#if lines.length === 0}
+    <div class="empty"><p>No compilation log yet</p></div>
+  {:else if shown.length === 0}
+    <div class="empty"><p>Nothing in the log matches</p></div>
+  {:else}
+    <div class="lines">
+      {#each shown.slice(0, MAX) as l (l.n)}
+        <div class="line {kind(l.text)}"><span class="ln" aria-hidden="true">{l.n}</span><span class="text">{l.text}</span></div>
+      {/each}
+      {#if shown.length > MAX}
+        <div class="more">{shown.length - MAX} more lines. Download the log for all of it.</div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .log { flex: 1; overflow-y: auto; font-family: var(--font-editor); font-size: 11px; display: flex; flex-direction: column; }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    background: var(--bg-elevated);
+    flex-shrink: 0;
+  }
+  .log-btn { font-size: 10.5px; padding: 2px 8px; color: var(--text-secondary); border: 1px solid var(--border); white-space: nowrap; }
+  .log-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
+  .log-btn:disabled { opacity: 0.4; cursor: default; }
+  .log-btn.active { color: var(--accent); border-color: var(--accent); }
+  .search {
+    flex: 1;
+    min-width: 60px;
+    font-size: 10.5px;
+    font-family: var(--font-editor);
+    padding: 2px 8px;
+    background: var(--bg-deep);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    outline: none;
+  }
+  .search:focus { border-color: var(--accent); }
+  .search::placeholder { color: var(--text-muted); }
+  .meta { font-size: 10px; color: var(--text-muted); white-space: nowrap; }
+
+  .lines { padding: 6px 0; }
+  .line { display: flex; gap: 8px; padding: 1px 8px; line-height: 1.5; color: var(--text-secondary); }
+  .line:hover { background: var(--bg-hover); }
+  .ln { flex-shrink: 0; width: 34px; text-align: right; color: var(--text-muted); opacity: 0.5; user-select: none; font-size: 10px; }
+  .text { white-space: pre-wrap; word-break: break-all; min-width: 0; }
+  .line.error { color: var(--error); }
+  .line.error .text { font-weight: 600; }
+  .line.warning { color: var(--warning); }
+  .line.context { color: var(--text-primary); }
+  .line.box { color: var(--text-muted); font-style: italic; }
+  .line.file { color: var(--text-muted); opacity: 0.7; }
+  .line.page { color: var(--accent); opacity: 0.8; }
+  .line.ok { color: var(--success); }
+  .line.meta { color: var(--text-muted); }
+  .more { padding: 6px 8px; color: var(--text-muted); font-style: italic; }
+  .empty { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: 12px; }
+</style>

--- a/src/lib/ui/ProblemsPanel.svelte
+++ b/src/lib/ui/ProblemsPanel.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import type { Problem } from '$lib/compiler/log';
+
+  export let problems: Problem[] = [];
+  // whether a compile happened at all, the empty state reads differently
+  export let compiled = false;
+
+  const ORDER = { error: 0, warning: 1, info: 2 };
+  const BADGE = { error: 'E', warning: 'W', info: 'N' };
+
+  $: sorted = [...problems].sort((a, b) => ORDER[a.severity] - ORDER[b.severity]);
+  $: errors = problems.filter(p => p.severity === 'error').length;
+  $: warnings = problems.filter(p => p.severity === 'warning').length;
+  $: notes = problems.filter(p => p.severity === 'info').length;
+
+  function plural(n: number, word: string): string {
+    return `${n} ${word}${n === 1 ? '' : 's'}`;
+  }
+
+  function where(p: Problem): string {
+    const file = p.file ? (p.inPackage ? `${p.file} (a package)` : p.file) : '';
+    return [file, p.line ? `line ${p.line}` : ''].filter(Boolean).join(', ');
+  }
+</script>
+
+<div class="problems">
+  {#if problems.length === 0}
+    <div class="empty">
+      {#if compiled}
+        <p class="empty-title">No problems</p>
+        <p class="empty-hint">LaTeX had nothing to complain about.</p>
+      {:else}
+        <p class="empty-title">Nothing compiled yet</p>
+        <p class="empty-hint">Press Compile, and anything LaTeX complains about shows up here in plain words.</p>
+      {/if}
+    </div>
+  {:else}
+    <p class="summary">
+      {[errors > 0 ? plural(errors, 'error') : '', warnings > 0 ? plural(warnings, 'warning') : '', notes > 0 ? plural(notes, 'note') : ''].filter(Boolean).join(', ')}
+    </p>
+    {#each sorted as p, i (i)}
+      <article class="card {p.severity}">
+        <header class="card-head">
+          <span class="badge" aria-label={p.severity}>{BADGE[p.severity]}</span>
+          <h4 class="title">{p.title}</h4>
+          {#if p.count > 1}<span class="count" title="Reported {p.count} times">&times;{p.count}</span>{/if}
+          {#if where(p)}<span class="where">{where(p)}</span>{/if}
+        </header>
+        {#if p.explain}
+          <p class="explain">{p.explain}</p>
+        {/if}
+        {#if p.fix}
+          <p class="fix"><span class="fix-label">Try</span>{p.fix}</p>
+        {/if}
+        {#if p.message !== p.title}
+          <p class="said"><span class="said-label">LaTeX said</span><code>{p.message}</code></p>
+        {/if}
+      </article>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .problems { flex: 1; overflow-y: auto; padding: 8px; display: flex; flex-direction: column; gap: 6px; }
+
+  .empty { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 4px; padding: 24px; }
+  .empty-title { font-size: 13px; font-weight: 600; color: var(--text-primary); margin: 0; }
+  .empty-hint { font-size: 12px; color: var(--text-muted); margin: 0; max-width: 320px; line-height: 1.5; }
+
+  .summary { font-size: 10.5px; font-family: var(--font-editor); color: var(--text-muted); margin: 0 0 2px; padding: 0 2px; }
+
+  .card {
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--text-muted);
+    background: var(--bg-surface);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .card.error { border-left-color: var(--error); }
+  .card.warning { border-left-color: var(--warning); }
+  .card.info { border-left-color: var(--text-muted); }
+
+  .card-head { display: flex; align-items: baseline; gap: 7px; flex-wrap: wrap; }
+  .badge {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: 700;
+    font-family: var(--font-editor);
+    color: #111;
+    background: var(--text-muted);
+    align-self: center;
+  }
+  .error .badge { background: var(--error); color: #fff; }
+  .warning .badge { background: var(--warning); }
+  .title { font-size: 12.5px; font-weight: 600; color: var(--text-primary); margin: 0; flex: 1; min-width: 0; }
+  .count { font-size: 10px; font-family: var(--font-editor); color: var(--text-muted); }
+  .where { font-size: 10.5px; font-family: var(--font-editor); color: var(--text-muted); white-space: nowrap; }
+
+  .explain { font-size: 12px; line-height: 1.5; color: var(--text-secondary); margin: 0; }
+  .fix { font-size: 12px; line-height: 1.5; color: var(--text-secondary); margin: 0; display: flex; gap: 8px; align-items: baseline; }
+  .fix-label {
+    flex-shrink: 0;
+    font-size: 9.5px;
+    font-weight: 700;
+    font-family: var(--font-editor);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--accent);
+    padding-top: 2px;
+  }
+  .said { font-size: 11px; color: var(--text-muted); margin: 0; display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .said-label { font-size: 9.5px; font-family: var(--font-editor); text-transform: uppercase; letter-spacing: 0.04em; flex-shrink: 0; padding-top: 2px; }
+  .said code { font-family: var(--font-editor); font-size: 10.5px; color: var(--text-secondary); word-break: break-word; }
+</style>

--- a/src/lib/ui/ProblemsPanel.svelte
+++ b/src/lib/ui/ProblemsPanel.svelte
@@ -4,6 +4,11 @@
   export let problems: Problem[] = [];
   // whether a compile happened at all, the empty state reads differently
   export let compiled = false;
+  export let onJump: (p: Problem) => void = () => {};
+
+  function canJump(p: Problem): boolean {
+    return !!p.file && !!p.line && !p.inPackage;
+  }
 
   const ORDER = { error: 0, warning: 1, info: 2 };
   const BADGE = { error: 'E', warning: 'W', info: 'N' };
@@ -42,9 +47,17 @@
       <article class="card {p.severity}">
         <header class="card-head">
           <span class="badge" aria-label={p.severity}>{BADGE[p.severity]}</span>
-          <h4 class="title">{p.title}</h4>
+          {#if canJump(p)}
+            <button class="title jump" on:click={() => onJump(p)} title="Go to {where(p)}">{p.title}</button>
+          {:else}
+            <h4 class="title">{p.title}</h4>
+          {/if}
           {#if p.count > 1}<span class="count" title="Reported {p.count} times">&times;{p.count}</span>{/if}
-          {#if where(p)}<span class="where">{where(p)}</span>{/if}
+          {#if canJump(p)}
+            <button class="where jump" on:click={() => onJump(p)}>{where(p)} &rarr;</button>
+          {:else if where(p)}
+            <span class="where">{where(p)}</span>
+          {/if}
         </header>
         {#if p.explain}
           <p class="explain">{p.explain}</p>
@@ -99,9 +112,14 @@
   }
   .error .badge { background: var(--error); color: #fff; }
   .warning .badge { background: var(--warning); }
-  .title { font-size: 12.5px; font-weight: 600; color: var(--text-primary); margin: 0; flex: 1; min-width: 0; }
+  .title { font-size: 12.5px; font-weight: 600; color: var(--text-primary); margin: 0; flex: 1; min-width: 0; text-align: left; }
   .count { font-size: 10px; font-family: var(--font-editor); color: var(--text-muted); }
   .where { font-size: 10.5px; font-family: var(--font-editor); color: var(--text-muted); white-space: nowrap; }
+  .jump { cursor: pointer; }
+  .title.jump:hover { text-decoration: underline; }
+  .where.jump { color: var(--accent); }
+  .where.jump:hover { color: var(--accent-hover); text-decoration: underline; }
+  .jump:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
   .explain { font-size: 12px; line-height: 1.5; color: var(--text-secondary); margin: 0; }
   .fix { font-size: 12px; line-height: 1.5; color: var(--text-secondary); margin: 0; display: flex; gap: 8px; align-items: baseline; }

--- a/src/lib/ui/ProblemsPanel.svelte
+++ b/src/lib/ui/ProblemsPanel.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
-  import type { Problem } from '$lib/compiler/log';
+  import { problemText, problemsReport, type Problem } from '$lib/compiler/log';
+  import { addToast } from '$lib/stores/app';
 
   export let problems: Problem[] = [];
   // whether a compile happened at all, the empty state reads differently
   export let compiled = false;
+  export let mainFile = 'document';
   export let onJump: (p: Problem) => void = () => {};
+
+  async function copy(text: string, what: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      addToast(`${what} copied`, 'success', 1500);
+    } catch {
+      addToast('Could not copy. Select the text and copy it by hand.', 'error');
+    }
+  }
 
   function canJump(p: Problem): boolean {
     return !!p.file && !!p.line && !p.inPackage;
@@ -55,6 +66,8 @@
       <button class="chip error" class:on={showErrors} aria-pressed={showErrors} on:click={() => (showErrors = !showErrors)} disabled={errors === 0}>{plural(errors, 'error')}</button>
       <button class="chip warning" class:on={showWarnings} aria-pressed={showWarnings} on:click={() => (showWarnings = !showWarnings)} disabled={warnings === 0}>{plural(warnings, 'warning')}</button>
       <button class="chip info" class:on={showNotes} aria-pressed={showNotes} on:click={() => (showNotes = !showNotes)} disabled={notes === 0} title="Overfull lines, stretched spaces, substituted fonts">{plural(notes, 'note')}</button>
+      <div style="flex:1"></div>
+      <button class="chip" on:click={() => copy(problemsReport(visible, mainFile), 'All problems')} disabled={visible.length === 0} title="Everything shown here as plain text, ready to paste">Copy all</button>
     </div>
     {#if visible.length === 0}
       <div class="empty">
@@ -82,6 +95,9 @@
           {:else if where(p)}
             <span class="where">{where(p)}</span>
           {/if}
+          <button class="icon-btn" on:click={() => copy(problemText(p), 'Problem')} title="Copy this problem as text" aria-label="Copy this problem as text">
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="5" y="5" width="9" height="9" rx="1" stroke="currentColor" stroke-width="1.2"/><path d="M11 5V3a1 1 0 00-1-1H3a1 1 0 00-1 1v7a1 1 0 001 1h2" stroke="currentColor" stroke-width="1.2"/></svg>
+          </button>
         </header>
         {#if p.explain}
           <p class="explain">{p.explain}</p>
@@ -167,6 +183,9 @@
   .title { font-size: 12.5px; font-weight: 600; color: var(--text-primary); margin: 0; flex: 1; min-width: 0; text-align: left; }
   .count { font-size: 10px; font-family: var(--font-editor); color: var(--text-muted); }
   .where { font-size: 10.5px; font-family: var(--font-editor); color: var(--text-muted); white-space: nowrap; }
+  .icon-btn { width: 20px; height: 20px; display: inline-flex; align-items: center; justify-content: center; color: var(--text-muted); align-self: center; flex-shrink: 0; }
+  .icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+  .icon-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
   .jump { cursor: pointer; }
   .title.jump:hover { text-decoration: underline; }
   .where.jump { color: var(--accent); }

--- a/src/lib/ui/ProblemsPanel.svelte
+++ b/src/lib/ui/ProblemsPanel.svelte
@@ -65,8 +65,20 @@
         {#if p.fix}
           <p class="fix"><span class="fix-label">Try</span>{p.fix}</p>
         {/if}
+        {#if p.context && (p.context.before || p.context.after)}
+          <div class="spot">
+            <code class="spot-code"><span>{p.context.before}</span><span class="spot-mark" role="img" aria-label="TeX stopped reading here"></span><span class="spot-after">{p.context.after}</span></code>
+            <span class="spot-label">the line as TeX read it, the bar is where it stopped</span>
+          </div>
+        {/if}
         {#if p.message !== p.title}
           <p class="said"><span class="said-label">LaTeX said</span><code>{p.message}</code></p>
+        {/if}
+        {#if p.excerpt.length > 1}
+          <details class="raw">
+            <summary>What the log says</summary>
+            <pre>{p.excerpt.join('\n')}</pre>
+          </details>
         {/if}
       </article>
     {/each}
@@ -132,6 +144,44 @@
     letter-spacing: 0.04em;
     color: var(--accent);
     padding-top: 2px;
+  }
+  .spot { display: flex; flex-direction: column; gap: 3px; }
+  .spot-code {
+    display: block;
+    font-family: var(--font-editor);
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--text-primary);
+    background: var(--bg-deep);
+    border: 1px solid var(--border);
+    padding: 5px 8px;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .spot-mark {
+    display: inline-block;
+    width: 2px;
+    height: 1.1em;
+    margin: 0 1px;
+    vertical-align: text-bottom;
+    background: var(--error);
+  }
+  .warning .spot-mark { background: var(--warning); }
+  .spot-after { color: var(--text-muted); }
+  .spot-label { font-size: 9.5px; font-family: var(--font-editor); color: var(--text-muted); }
+  .raw summary { font-size: 10.5px; color: var(--accent); cursor: pointer; }
+  .raw summary:hover { color: var(--accent-hover); }
+  .raw pre {
+    margin: 4px 0 0;
+    padding: 6px 8px;
+    font-family: var(--font-editor);
+    font-size: 10.5px;
+    line-height: 1.45;
+    color: var(--text-muted);
+    background: var(--bg-deep);
+    border: 1px solid var(--border);
+    white-space: pre-wrap;
+    word-break: break-word;
   }
   .said { font-size: 11px; color: var(--text-muted); margin: 0; display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
   .said-label { font-size: 9.5px; font-family: var(--font-editor); text-transform: uppercase; letter-spacing: 0.04em; flex-shrink: 0; padding-top: 2px; }

--- a/src/lib/ui/ProblemsPanel.svelte
+++ b/src/lib/ui/ProblemsPanel.svelte
@@ -13,10 +13,21 @@
   const ORDER = { error: 0, warning: 1, info: 2 };
   const BADGE = { error: 'E', warning: 'W', info: 'N' };
 
+  // notes are about margins and spacing, most people never want them in
+  // the way, so they start hidden
+  let showErrors = true;
+  let showWarnings = true;
+  let showNotes = false;
+
   $: sorted = [...problems].sort((a, b) => ORDER[a.severity] - ORDER[b.severity]);
   $: errors = problems.filter(p => p.severity === 'error').length;
   $: warnings = problems.filter(p => p.severity === 'warning').length;
   $: notes = problems.filter(p => p.severity === 'info').length;
+  $: visible = sorted.filter(p =>
+    (p.severity === 'error' && showErrors) ||
+    (p.severity === 'warning' && showWarnings) ||
+    (p.severity === 'info' && showNotes)
+  );
 
   function plural(n: number, word: string): string {
     return `${n} ${word}${n === 1 ? '' : 's'}`;
@@ -40,10 +51,23 @@
       {/if}
     </div>
   {:else}
-    <p class="summary">
-      {[errors > 0 ? plural(errors, 'error') : '', warnings > 0 ? plural(warnings, 'warning') : '', notes > 0 ? plural(notes, 'note') : ''].filter(Boolean).join(', ')}
-    </p>
-    {#each sorted as p, i (i)}
+    <div class="chips" role="group" aria-label="Which problems to show">
+      <button class="chip error" class:on={showErrors} aria-pressed={showErrors} on:click={() => (showErrors = !showErrors)} disabled={errors === 0}>{plural(errors, 'error')}</button>
+      <button class="chip warning" class:on={showWarnings} aria-pressed={showWarnings} on:click={() => (showWarnings = !showWarnings)} disabled={warnings === 0}>{plural(warnings, 'warning')}</button>
+      <button class="chip info" class:on={showNotes} aria-pressed={showNotes} on:click={() => (showNotes = !showNotes)} disabled={notes === 0} title="Overfull lines, stretched spaces, substituted fonts">{plural(notes, 'note')}</button>
+    </div>
+    {#if visible.length === 0}
+      <div class="empty">
+        {#if errors === 0 && warnings === 0}
+          <p class="empty-title">No errors, no warnings</p>
+          <p class="empty-hint">{plural(notes, 'note')} about margins and spacing {notes === 1 ? 'is' : 'are'} hidden. Turn them on above if the layout matters right now.</p>
+        {:else}
+          <p class="empty-title">Everything is filtered out</p>
+          <p class="empty-hint">Turn a kind back on above.</p>
+        {/if}
+      </div>
+    {/if}
+    {#each visible as p, i (i)}
       <article class="card {p.severity}">
         <header class="card-head">
           <span class="badge" aria-label={p.severity}>{BADGE[p.severity]}</span>
@@ -92,7 +116,23 @@
   .empty-title { font-size: 13px; font-weight: 600; color: var(--text-primary); margin: 0; }
   .empty-hint { font-size: 12px; color: var(--text-muted); margin: 0; max-width: 320px; line-height: 1.5; }
 
-  .summary { font-size: 10.5px; font-family: var(--font-editor); color: var(--text-muted); margin: 0 0 2px; padding: 0 2px; }
+  .chips { display: flex; gap: 6px; flex-wrap: wrap; padding: 0 2px 2px; }
+  .chip {
+    font-size: 10.5px;
+    font-family: var(--font-editor);
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    background: transparent;
+    cursor: pointer;
+  }
+  .chip:hover:not(:disabled) { background: var(--bg-hover); }
+  .chip:disabled { opacity: 0.4; cursor: default; }
+  .chip.on { color: var(--text-primary); border-color: currentColor; }
+  .chip.error.on { color: var(--error); }
+  .chip.warning.on { color: var(--warning); }
+  .chip.info.on { color: var(--text-secondary); }
+  .chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
   .card {
     border: 1px solid var(--border);

--- a/src/lib/ui/ProblemsPanel.svelte
+++ b/src/lib/ui/ProblemsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { problemText, problemsReport, type Problem } from '$lib/compiler/log';
+  import { problemText, problemsReport, looksLikeOurs, issueUrl, type Problem } from '$lib/compiler/log';
   import { addToast } from '$lib/stores/app';
 
   export let problems: Problem[] = [];
@@ -119,6 +119,12 @@
             <summary>What the log says</summary>
             <pre>{p.excerpt.join('\n')}</pre>
           </details>
+        {/if}
+        {#if looksLikeOurs(p)}
+          <p class="report">
+            This may be TeXbrain's doing rather than your document's.
+            <a href={issueUrl(p, mainFile)} target="_blank" rel="noopener">Report it, the details are filled in &#8599;</a>
+          </p>
         {/if}
       </article>
     {/each}
@@ -242,6 +248,9 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
+  .report { font-size: 11px; color: var(--text-muted); margin: 0; line-height: 1.5; }
+  .report a { color: var(--accent); text-decoration: none; }
+  .report a:hover { color: var(--accent-hover); text-decoration: underline; }
   .said { font-size: 11px; color: var(--text-muted); margin: 0; display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
   .said-label { font-size: 9.5px; font-family: var(--font-editor); text-transform: uppercase; letter-spacing: 0.04em; flex-shrink: 0; padding-top: 2px; }
   .said code { font-family: var(--font-editor); font-size: 10.5px; color: var(--text-secondary); word-break: break-word; }

--- a/src/lib/ui/StatusBar.svelte
+++ b/src/lib/ui/StatusBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { compileStatus } from '$lib/stores/app';
+  import { compileStatus, compileProblems, previewTab, previewOpen } from '$lib/stores/app';
   import { activeFile } from '$lib/project/store';
   import { gitEnabled, gitCurrentBranch } from '$lib/git/store';
 
@@ -7,6 +7,20 @@
   export let cursorCol = 1;
   export let charCount = 0;
   export let wordCount = 0;
+
+  $: errors = $compileProblems.filter(p => p.severity === 'error').length;
+  $: warnings = $compileProblems.filter(p => p.severity === 'warning').length;
+
+  function plural(n: number, word: string): string {
+    return `${n} ${word}${n === 1 ? '' : 's'}`;
+  }
+
+  // one click from the status bar to the problems, even when the preview
+  // pane is closed
+  function showProblems() {
+    previewOpen.set(true);
+    previewTab.set('problems');
+  }
 </script>
 
 <div class="status-bar">
@@ -26,6 +40,12 @@
         Idle
       {/if}
     </span>
+    {#if $compileStatus !== 'compiling' && (errors > 0 || warnings > 0)}
+      <span class="sep"></span>
+      <button class="status-item problems" class:has-errors={errors > 0} on:click={showProblems} title="Show the problems">
+        {[errors > 0 ? plural(errors, 'error') : '', warnings > 0 ? plural(warnings, 'warning') : ''].filter(Boolean).join(', ')}
+      </button>
+    {/if}
     {#if $gitEnabled}
       <span class="sep"></span>
       <span class="status-item">
@@ -89,6 +109,10 @@
     background: var(--border);
     margin: 0 4px;
   }
+
+  .problems { color: var(--warning); cursor: pointer; font-family: inherit; font-size: inherit; padding: 0 2px; }
+  .problems.has-errors { color: var(--error); }
+  .problems:hover { text-decoration: underline; }
 
   .dot {
     width: 5px;

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -1135,7 +1135,6 @@
     color: white;
   }
 
-  .preview-empty { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-muted); font-size: 12px; }
 
   @media (max-width: 600px) { .logo-text { display: none; } }
 

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -958,7 +958,7 @@
                 <PdfViewer bind:this={pdfViewer} {pdfData} />
               </div>
             {:else if $previewTab === 'problems'}
-              <ProblemsPanel problems={$compileProblems} compiled={$compileStatus !== 'idle'} onJump={jumpToProblem} />
+              <ProblemsPanel problems={$compileProblems} compiled={$compileStatus !== 'idle'} mainFile={$entryPoint || $activeFile?.name || 'document'} onJump={jumpToProblem} />
             {:else}
               <div class="log-content">
                 <div class="log-toolbar">

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -4,10 +4,12 @@
   import { browser } from '$app/environment';
   import { get } from 'svelte/store';
   import { sidebarOpen, previewOpen, snippetPickerOpen, commandPaletteOpen, cloneDialogOpen, compileStatus, compileLog, compileRawLog, compileProblems, previewTab, addToast } from '$lib/stores/app';
-  import { files, activeFile, activeFileId, updateFileContent, markFileSaved, projectHandle, entryPoint, openFileTab, closeFileTab } from '$lib/project/store';
+  import { files, activeFile, activeFileId, updateFileContent, markFileSaved, projectHandle, entryPoint, openFileTab, closeFileTab, setActiveTab } from '$lib/project/store';
   import { readFileFromHandle } from '$lib/fs/local-fs';
-  import { handleOpenFile, handleSaveFile, handleSaveFileAs, handleDroppedFiles, handleOpenDirectory, handleNewProject, cloneProject, reopenEntryPointPicker, refreshProjectTree, supportsFileSystemAccess } from '$lib/project/manager';
-  import { insertAtCursor, createEditor, replaceEditorContent } from '$lib/editor/setup';
+  import { handleOpenFile, handleSaveFile, handleSaveFileAs, handleDroppedFiles, handleOpenDirectory, handleNewProject, cloneProject, reopenEntryPointPicker, refreshProjectTree, supportsFileSystemAccess, findProjectFile, handleOpenFileFromTree } from '$lib/project/manager';
+  import { insertAtCursor, createEditor, replaceEditorContent, gotoLine } from '$lib/editor/setup';
+  import { tick } from 'svelte';
+  import { locateByNeedle, type Problem } from '$lib/compiler/log';
   import type { EditorView } from '@codemirror/view';
   import type { Snippet as SnippetDef } from '$lib/snippets/index';
   import { compileLaTeX, warmup } from '$lib/compiler/latex-engine';
@@ -376,6 +378,10 @@
       ]);
 
       const { problems, cleanedLines } = parseLog(result.log || '');
+      // tex gives no line for a missing package or a runaway argument, the
+      // sources usually do
+      locateByNeedle(problems, projectFiles);
+      for (const p of problems) if (!p.file) { p.file = mainFile; p.inPackage = false; }
       compileProblems.set(problems);
       compileRawLog.set(result.log || '');
 
@@ -470,6 +476,25 @@
   function handleResizeDelta(delta: number) {
     const cw = windowWidth - ($sidebarOpen ? 260 : 0);
     editorWidth = Math.max(25, Math.min(75, editorWidth + (delta / cw) * 100));
+  }
+
+  // a problem points at a file and a line, the editor goes there, opening
+  // the file from the project when it isn't open yet
+  async function jumpToProblem(p: Problem) {
+    if (!p.file || !p.line || p.inPackage) return;
+    const matches = (t: { path: string; name: string }) => t.path === p.file || t.name === p.file || t.path.endsWith('/' + p.file);
+    let tab = get(files).find(matches);
+    if (!tab) {
+      const entry = findProjectFile(p.file);
+      if (entry?.handle) {
+        await handleOpenFileFromTree(entry.handle, entry.path);
+        tab = get(files).find(matches);
+      }
+    }
+    if (!tab) { addToast(`${p.file} isn't open, and it isn't in the project folder either`, 'info', 4000); return; }
+    if (get(activeFileId) !== tab.id) setActiveTab(tab.id);
+    await tick();
+    if (editorView) gotoLine(editorView, p.line);
   }
 
   $: errorCount = $compileProblems.filter(p => p.severity === 'error').length;
@@ -933,7 +958,7 @@
                 <PdfViewer bind:this={pdfViewer} {pdfData} />
               </div>
             {:else if $previewTab === 'problems'}
-              <ProblemsPanel problems={$compileProblems} compiled={$compileStatus !== 'idle'} />
+              <ProblemsPanel problems={$compileProblems} compiled={$compileStatus !== 'idle'} onJump={jumpToProblem} />
             {:else}
               <div class="log-content">
                 <div class="log-toolbar">

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -3,7 +3,7 @@
   import { base } from '$app/paths';
   import { browser } from '$app/environment';
   import { get } from 'svelte/store';
-  import { sidebarOpen, previewOpen, snippetPickerOpen, commandPaletteOpen, cloneDialogOpen, compileStatus, compileLog, compileRawLog, compileErrors, previewTab, addToast } from '$lib/stores/app';
+  import { sidebarOpen, previewOpen, snippetPickerOpen, commandPaletteOpen, cloneDialogOpen, compileStatus, compileLog, compileRawLog, compileProblems, previewTab, addToast } from '$lib/stores/app';
   import { files, activeFile, activeFileId, updateFileContent, markFileSaved, projectHandle, entryPoint, openFileTab, closeFileTab } from '$lib/project/store';
   import { readFileFromHandle } from '$lib/fs/local-fs';
   import { handleOpenFile, handleSaveFile, handleSaveFileAs, handleDroppedFiles, handleOpenDirectory, handleNewProject, cloneProject, reopenEntryPointPicker, refreshProjectTree, supportsFileSystemAccess } from '$lib/project/manager';
@@ -35,6 +35,7 @@
   import SnippetPicker from '$lib/ui/SnippetPicker.svelte';
   import EntryPointPicker from '$lib/ui/EntryPointPicker.svelte';
   import PdfViewer from '$lib/ui/PdfViewer.svelte';
+  import ProblemsPanel from '$lib/ui/ProblemsPanel.svelte';
   import CollabPanel from '$lib/ui/CollabPanel.svelte';
   import GitPanel from '$lib/ui/GitPanel.svelte';
   import DrawioEditor from '$lib/ui/DrawioEditor.svelte';
@@ -375,10 +376,7 @@
       ]);
 
       const { problems, cleanedLines } = parseLog(result.log || '');
-      const parsedErrors = problems
-        .filter(p => p.severity !== 'info')
-        .map(p => ({ type: p.severity as 'error' | 'warning', message: p.title, line: p.line, file: p.file }));
-      compileErrors.set(parsedErrors);
+      compileProblems.set(problems);
       compileRawLog.set(result.log || '');
 
       if (result.status === 0 && result.pdf) {
@@ -392,20 +390,20 @@
         compileStatus.set('success');
         compileLog.set([`[${ts()}] compilation successful (${pdfPageCount} pages)`, ...capLogLines(cleanedLines)]);
 
-        if (parsedErrors.some(e => e.type === 'error')) {
-          previewTab.set('errors');
+        if (problems.some(p => p.severity === 'error')) {
+          previewTab.set('problems');
         }
 
         if (isCollabMode) {
-          setCompileResult({ status: 'success', pdf: pdfData, log: cleanedLines, errors: parsedErrors, pageCount: pdfPageCount });
+          setCompileResult({ status: 'success', pdf: pdfData, log: cleanedLines, errors: problems, pageCount: pdfPageCount });
         }
       } else {
         compileStatus.set('error');
         compileLog.set([`[${ts()}] compilation failed (status ${result.status})`, ...capLogLines(cleanedLines)]);
-        previewTab.set('errors');
+        previewTab.set('problems');
 
         if (isCollabMode) {
-          setCompileResult({ status: 'error', pdf: null, log: cleanedLines, errors: parsedErrors, pageCount: pdfPageCount });
+          setCompileResult({ status: 'error', pdf: null, log: cleanedLines, errors: problems, pageCount: pdfPageCount });
         }
       }
     } catch (err: any) {
@@ -413,7 +411,7 @@
       compileLog.update(log => [...log, `[error] ${err.message || String(err)}`]);
 
       if (isCollabMode) {
-        setCompileResult({ status: 'error', pdf: null, log: [`[error] ${err.message || String(err)}`], errors: [{ type: 'error', message: err.message || String(err) }], pageCount: 0 });
+        setCompileResult({ status: 'error', pdf: null, log: [`[error] ${err.message || String(err)}`], errors: [{ severity: 'error', title: err.message || String(err), message: err.message || String(err), inPackage: false, excerpt: [], count: 1 }], pageCount: 0 });
       }
     } finally {
       compiling = false;
@@ -424,10 +422,6 @@
   function compilePreview() { doCompile(); }
 
   function ts() { return new Date().toLocaleTimeString(); }
-
-  function errorLocation(e: { line?: number; file?: string }): string {
-    return [e.file, e.line ? `line ${e.line}` : ''].filter(Boolean).join(', ');
-  }
 
   async function saveAndCompile() {
     await handleSaveFile();
@@ -477,6 +471,9 @@
     const cw = windowWidth - ($sidebarOpen ? 260 : 0);
     editorWidth = Math.max(25, Math.min(75, editorWidth + (delta / cw) * 100));
   }
+
+  $: errorCount = $compileProblems.filter(p => p.severity === 'error').length;
+  $: warningCount = $compileProblems.filter(p => p.severity === 'warning').length;
 
   // the log tab shows a cleaned version by default. the full transcript is
   // what you want when something fails deep inside a package
@@ -716,12 +713,12 @@
               pdfViewer?.setPageCount(pdfPageCount);
               compileStatus.set('success');
               compileLog.set([`[${ts()}] compilation successful (${pdfPageCount} pages)`, ...log]);
-              compileErrors.set(errors);
+              compileProblems.set(errors);
             } else {
               compileStatus.set('error');
               compileLog.set([`[${ts()}] compilation failed`, ...log]);
-              compileErrors.set(errors);
-              previewTab.set('errors');
+              compileProblems.set(errors);
+              previewTab.set('problems');
             }
           } catch (err) {
             console.error('failed to read compile result:', err);
@@ -914,16 +911,12 @@
           <div class="preview-pane" style="width:{100 - editorWidth}%">
             <div class="preview-header">
               <button class="preview-tab" class:active={$previewTab === 'preview'} on:click={() => previewTab.set('preview')}>Preview</button>
-              <button class="preview-tab" class:active={$previewTab === 'errors'} on:click={() => previewTab.set('errors')}>
-                Errors
-                {#if $compileErrors.filter(e => e.type === 'error').length > 0}
-                  <span class="error-badge has-errors">{$compileErrors.filter(e => e.type === 'error').length}</span>
-                {/if}
-              </button>
-              <button class="preview-tab" class:active={$previewTab === 'warnings'} on:click={() => previewTab.set('warnings')}>
-                Warnings
-                {#if $compileErrors.filter(e => e.type === 'warning').length > 0}
-                  <span class="error-badge">{$compileErrors.filter(e => e.type === 'warning').length}</span>
+              <button class="preview-tab" class:active={$previewTab === 'problems'} on:click={() => previewTab.set('problems')}>
+                Problems
+                {#if errorCount > 0}
+                  <span class="error-badge has-errors">{errorCount}</span>
+                {:else if warningCount > 0}
+                  <span class="error-badge">{warningCount}</span>
                 {/if}
               </button>
               <button class="preview-tab" class:active={$previewTab === 'log'} on:click={() => previewTab.set('log')}>Log</button>
@@ -939,38 +932,8 @@
               <div class="preview-content">
                 <PdfViewer bind:this={pdfViewer} {pdfData} />
               </div>
-            {:else if $previewTab === 'errors'}
-              <div class="errors-content">
-                {#if $compileErrors.filter(e => e.type === 'error').length === 0}
-                  <div class="preview-empty"><p>No errors</p></div>
-                {:else}
-                  {#each $compileErrors.filter(e => e.type === 'error') as err}
-                    <div class="error-item is-error">
-                      <span class="error-type-badge err-badge">E</span>
-                      <span class="error-msg">{err.message}</span>
-                      {#if err.file || err.line}
-                        <span class="error-line">{errorLocation(err)}</span>
-                      {/if}
-                    </div>
-                  {/each}
-                {/if}
-              </div>
-            {:else if $previewTab === 'warnings'}
-              <div class="errors-content">
-                {#if $compileErrors.filter(e => e.type === 'warning').length === 0}
-                  <div class="preview-empty"><p>No warnings</p></div>
-                {:else}
-                  {#each $compileErrors.filter(e => e.type === 'warning') as warn}
-                    <div class="error-item is-warning">
-                      <span class="error-type-badge warn-badge">W</span>
-                      <span class="error-msg">{warn.message}</span>
-                      {#if warn.file || warn.line}
-                        <span class="error-line">{errorLocation(warn)}</span>
-                      {/if}
-                    </div>
-                  {/each}
-                {/if}
-              </div>
+            {:else if $previewTab === 'problems'}
+              <ProblemsPanel problems={$compileProblems} compiled={$compileStatus !== 'idle'} />
             {:else}
               <div class="log-content">
                 <div class="log-toolbar">
@@ -1203,39 +1166,6 @@
     color: white;
   }
 
-  .errors-content { flex: 1; overflow-y: auto; padding: 6px; }
-  .error-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 6px;
-    padding: 6px 8px;
-    margin-bottom: 2px;
-    font-size: 11.5px;
-    font-family: var(--font-editor);
-    line-height: 1.5;
-  }
-  .error-item.is-error { background: rgba(224, 108, 117, 0.06); }
-  .error-item.is-warning { background: rgba(229, 192, 123, 0.06); }
-  .error-type-badge {
-    flex-shrink: 0;
-    width: 16px;
-    height: 16px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 9px;
-    font-weight: 700;
-  }
-  .err-badge { background: var(--error); color: white; }
-  .warn-badge { background: var(--warning); color: #000; }
-  .error-msg { flex: 1; color: var(--text-primary); word-break: break-word; }
-  .error-line {
-    flex-shrink: 0;
-    font-size: 10px;
-    color: var(--text-muted);
-    padding: 0 4px;
-    background: var(--bg-hover);
-  }
   .preview-empty { display: flex; align-items: center; justify-content: center; height: 100%; color: var(--text-muted); font-size: 12px; }
 
   @media (max-width: 600px) { .logo-text { display: none; } }

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -374,7 +374,10 @@
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error('compilation timed out after 180s')), 180_000))
       ]);
 
-      const { errors: parsedErrors, cleanedLines } = parseLog(result.log || '');
+      const { problems, cleanedLines } = parseLog(result.log || '');
+      const parsedErrors = problems
+        .filter(p => p.severity !== 'info')
+        .map(p => ({ type: p.severity as 'error' | 'warning', message: p.title, line: p.line, file: p.file }));
       compileErrors.set(parsedErrors);
       compileRawLog.set(result.log || '');
 

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -38,6 +38,7 @@
   import EntryPointPicker from '$lib/ui/EntryPointPicker.svelte';
   import PdfViewer from '$lib/ui/PdfViewer.svelte';
   import ProblemsPanel from '$lib/ui/ProblemsPanel.svelte';
+  import LogPanel from '$lib/ui/LogPanel.svelte';
   import CollabPanel from '$lib/ui/CollabPanel.svelte';
   import GitPanel from '$lib/ui/GitPanel.svelte';
   import DrawioEditor from '$lib/ui/DrawioEditor.svelte';
@@ -500,32 +501,9 @@
   $: errorCount = $compileProblems.filter(p => p.severity === 'error').length;
   $: warningCount = $compileProblems.filter(p => p.severity === 'warning').length;
 
-  // the log tab shows a cleaned version by default. the full transcript is
-  // what you want when something fails deep inside a package
-  let fullLog = false;
-
   function logFileName(): string {
     const ep = get(entryPoint);
     return (ep ? ep.replace(/^.*[\\/]/, '').replace(/\.tex$/, '') : 'document') + '.log';
-  }
-
-  async function copyLog() {
-    try {
-      await navigator.clipboard.writeText(get(compileRawLog));
-      addToast('Log copied', 'success', 1500);
-    } catch {
-      addToast('Could not copy, use download instead', 'error');
-    }
-  }
-
-  function downloadLog() {
-    const blob = new Blob([get(compileRawLog)], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = logFileName();
-    a.click();
-    URL.revokeObjectURL(url);
   }
 
   function savePdf() {
@@ -960,30 +938,7 @@
             {:else if $previewTab === 'problems'}
               <ProblemsPanel problems={$compileProblems} compiled={$compileStatus !== 'idle'} mainFile={$entryPoint || $activeFile?.name || 'document'} onJump={jumpToProblem} />
             {:else}
-              <div class="log-content">
-                <div class="log-toolbar">
-                  <button class="log-btn" class:active={fullLog} on:click={() => (fullLog = !fullLog)} aria-pressed={fullLog} title="Everything the engine printed, nothing filtered">Full log</button>
-                  <div style="flex:1"></div>
-                  <button class="log-btn" on:click={copyLog} disabled={!$compileRawLog} title="Copy the full log to the clipboard">Copy</button>
-                  <button class="log-btn" on:click={downloadLog} disabled={!$compileRawLog} title="Download the full log as a file">Download</button>
-                </div>
-                {#if fullLog}
-                  {#if $compileRawLog}
-                    <pre class="log-raw">{$compileRawLog}</pre>
-                  {:else}
-                    <div class="preview-empty"><p>No compilation log yet</p></div>
-                  {/if}
-                {:else}
-                  <div class="log-entries">
-                    {#each $compileLog as entry}
-                      <div class="log-entry" class:error={entry.includes('[Error]') || entry.includes('!')} class:success={entry.includes('successful')}>{entry}</div>
-                    {/each}
-                  </div>
-                  {#if $compileLog.length === 0}
-                    <div class="preview-empty"><p>No compilation log yet</p></div>
-                  {/if}
-                {/if}
-              </div>
+              <LogPanel raw={$compileRawLog} cleaned={$compileLog} fileName={logFileName()} />
             {/if}
           </div>
         {/if}
@@ -1128,17 +1083,6 @@
   .preview-tab.active { color: var(--text-primary); background: var(--bg-hover); }
   .preview-content { flex: 1; overflow: hidden; display: flex; }
 
-  .log-content { flex: 1; overflow-y: auto; font-family: var(--font-editor); font-size: 11px; display: flex; flex-direction: column; }
-  .log-toolbar { display: flex; align-items: center; gap: 4px; padding: 4px 8px; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg-elevated); flex-shrink: 0; }
-  .log-btn { font-size: 10.5px; padding: 2px 8px; color: var(--text-secondary); border: 1px solid var(--border); }
-  .log-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
-  .log-btn:disabled { opacity: 0.4; cursor: default; }
-  .log-btn.active { color: var(--accent); border-color: var(--accent); }
-  .log-entries { padding: 8px; }
-  .log-raw { margin: 0; padding: 8px; white-space: pre-wrap; word-break: break-all; color: var(--text-secondary); line-height: 1.45; }
-  .log-entry { padding: 2px 6px; color: var(--text-secondary); margin-bottom: 1px; white-space: pre-wrap; word-break: break-all; }
-  .log-entry.error { color: var(--error); }
-  .log-entry.success { color: var(--success); }
 
   .welcome-state { flex: 1; display: flex; align-items: center; justify-content: center; overflow-y: auto; padding: 32px 20px; }
   .welcome-content { text-align: center; max-width: 560px; }

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -146,6 +146,7 @@
             parent: editorContainer,
             dark: true,
             onUpdate: handleEditorUpdate,
+            onCursor: handleCursor,
             collab: yCollab(data.ytext, awareness, { undoManager: data.undoManager })
           });
           setCurrentFile(file.path);
@@ -155,7 +156,8 @@
           doc: file.content,
           parent: editorContainer,
           dark: true,
-          onUpdate: handleEditorUpdate
+          onUpdate: handleEditorUpdate,
+          onCursor: handleCursor
         });
       }
     } catch (err) {
@@ -438,15 +440,14 @@
   function handleEditorUpdate(content: string) {
     if (!$activeFile) return;
     updateFileContent($activeFile.id, content);
-    if (editorView) {
-      const pos = editorView.state.selection.main.head;
-      const line = editorView.state.doc.lineAt(pos);
-      cursorLine = line.number;
-      cursorCol = pos - line.from + 1;
-      charCount = editorView.state.doc.length;
-      const text = editorView.state.doc.toString();
-      wordCount = text.trim() ? text.trim().split(/\s+/).length : 0;
-    }
+    charCount = content.length;
+    wordCount = content.trim() ? content.trim().split(/\s+/).length : 0;
+  }
+
+  // the status bar follows the cursor, not only the edits
+  function handleCursor(line: number, col: number) {
+    cursorLine = line;
+    cursorCol = col;
   }
 
   // double-click in editor jumps pdf to approximate cursor position


### PR DESCRIPTION
Errors, warnings and the log were the weakest part of the editor: raw TeX messages, no idea which file they came from, and a log that was a wall of text.

What changed

- One Problems tab instead of Errors and Warnings. Every problem is a card: a headline in plain words, what it means, what to try, file and line, and the source line as TeX read it with a bar where it stopped. Click it and the editor jumps there, opening the file if it has to.
- Notes about margins, stretched lines and substituted fonts are there too, hidden until you switch them on.
- Errors TeX can't place, a missing package for example, are placed by searching the sources.
- Copy one problem or all of them as text that reads well in an issue or a chat. Problems that look like the app's fault rather than the document's get a link that opens a prefilled issue.
- The log tab has colors, line numbers, search, a full/clean toggle, copy and download.
- The status bar counts the problems and opens them on click, and it follows the cursor now instead of only updating on edits.
- The parser is tested against 18 real transcripts from the engine, one per kind of mistake. pnpm test runs with every check.
